### PR TITLE
fix: specify npm package is public

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+access = public


### PR DESCRIPTION
### What are the relevant tickets?
Attempting to fix broken release action: https://github.com/mitodl/smoot-design/actions/runs/11955738538

### Description (What does it do?)
When a scoped (`@mitodl/package-name`) package is first published to NPM, it defaults to private. Our account can't publish private packages (nor do we care to).

This sets the `--access public` flag in npmrc.

### How can this be tested?
Run `npm config get access` in this directory.
