### PR TITLE
chore: build package during prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint-check": "eslint src/ .storybook/",
     "lint-fix": "yarn lint-check --fix",
     "fmt-check": "prettier --ignore-path .gitignore --ignore-path .prettierignore --check .",
-    "fmt-fix": "prettier --ignore-path .gitignore --ignore-path .prettierignore --write ."
+    "fmt-fix": "prettier --ignore-path .gitignore --ignore-path .prettierignore --write .",
+    "prepack": "yarn build"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes NPM publishing.

### How can this be tested?
Run `npm publish --dry-run` locally. You should get a folder.

