### PR TITLE
docs: Use `react-docgen-typescript` for autodoc generation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   rules: {
     ...restrictedImports(),
+    "react/display-name": [2, {}],
     // This rule is disabled in the default a11y config, but unclear why.
     // It does catch useful errors, e.g., buttons with no text or label.
     // If it proves to be flaky, we can find other ways to check for this.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -33,12 +33,6 @@ const config: StorybookConfig = {
   },
 
   typescript: {
-    /**
-     * Note: In theory react-docgen-typescript should work better with TS, but
-     * it seems not to work particularly well:
-     *  - misses many props
-     *  - doesn't get docstrings from the source component
-     */
     reactDocgen: "react-docgen-typescript",
   },
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -39,7 +39,7 @@ const config: StorybookConfig = {
      *  - misses many props
      *  - doesn't get docstrings from the source component
      */
-    // reactDocgen: "react-docgen-typescript",
+    reactDocgen: "react-docgen-typescript",
   },
 }
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ To trigger a release, run the "Release" github action. Using [semantic-release](
 1. Inspect the commit history since previous release for [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) an
 2. Determine whether the version bump should be major, minor, or patch based on commit types. Breaking changes (e.g., `feat!: remove Button variant 'outlined'`) will result in major version bumps.
 3. Publish the package to NPM and the repository's [Github Releases](https://github.com/mitodl/smoot-design/releases).
+
+## Documentation
+
+Documentation for `smoot-design` components is available at https://mitodl.github.io/smoot-design.
+
+### Storybook
+
+Components in `smoot-design` are documented using Storybook's [autodocs](https://storybook.js.org/docs/writing-docs/autodocs) feature.
+
+Autodocs _should_ infer props and comments from Typescript + JSDoc comments. However, autodocs can be a bit finnicky. Tips:
+
+- **Filename should match Component Name:** If you're documenting `Button`, it must be exported from a file called `Button.tsx`.
+- **Component `displayName`:** Some components may need an explicit `displayName`, this can be set by `Button.displayName="Button"`.
+  - _React component display names are not visible to end users; they are used in React's Dev Tools. React automatically adds display names for most components while transpiling, but autodocs uses un-transpiled code to generate documentation._

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/mitodl/smoot-design"
   },
   "scripts": {
-    "storybook": "storybook dev -p 6006",
+    "start": "storybook dev -p 6006 --docs",
     "build-storybook": "storybook build --docs",
     "test": "jest",
     "typecheck": "tsc --noEmit",

--- a/src/components/Button/ActionButton.stories.tsx
+++ b/src/components/Button/ActionButton.stories.tsx
@@ -20,7 +20,7 @@ const ICONS = {
   TestTubeIcon: <RiTestTubeLine />,
 }
 
-const VARIANTS = enumValues<NonNullable<ActionButtonProps["variant"]>>({
+const VARIANTS = enumValues<ActionButtonProps["variant"]>({
   primary: true,
   secondary: true,
   tertiary: true,
@@ -30,12 +30,12 @@ const VARIANTS = enumValues<NonNullable<ActionButtonProps["variant"]>>({
   unstable_success: true,
 })
 const STABLE_VARIANTS = VARIANTS.filter((v) => !v.startsWith("unstable"))
-const SIZES = enumValues<NonNullable<ActionButtonProps["size"]>>({
+const SIZES = enumValues<ActionButtonProps["size"]>({
   small: true,
   medium: true,
   large: true,
 })
-const EDGES = enumValues<NonNullable<ActionButtonProps["edge"]>>({
+const EDGES = enumValues<ActionButtonProps["edge"]>({
   circular: true,
   rounded: true,
   none: true,

--- a/src/components/Button/ActionButton.stories.tsx
+++ b/src/components/Button/ActionButton.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { ActionButton, ActionButtonLink, DEFAULT_PROPS } from "./Button"
-import type { ActionButtonProps } from "./Button"
+import { ActionButton, ActionButtonLink, DEFAULT_PROPS } from "./ActionButton"
+import type { ActionButtonProps } from "./ActionButton"
 import Grid from "@mui/material/Grid2"
 import Stack from "@mui/material/Stack"
 import {
@@ -11,7 +11,7 @@ import {
 } from "@remixicon/react"
 
 import { fn } from "@storybook/test"
-import { enumValues, docsEnum } from "@/story-utils"
+import { enumValues } from "@/story-utils"
 
 const ICONS = {
   None: undefined,
@@ -41,34 +41,25 @@ const EDGES = enumValues<NonNullable<ActionButtonProps["edge"]>>({
   none: true,
 })
 
-/**
- * A button that should contain a remixicon icon and nothing else.
- */
 const meta: Meta<typeof ActionButton> = {
   title: "smoot-design/ActionButton",
   component: ActionButton,
   argTypes: {
     variant: {
-      options: VARIANTS,
       control: { type: "select" },
       table: {
-        type: { summary: docsEnum(VARIANTS) },
         defaultValue: { summary: DEFAULT_PROPS.variant },
       },
     },
     size: {
-      options: SIZES,
       control: { type: "select" },
       table: {
-        type: { summary: docsEnum(SIZES) },
         defaultValue: { summary: DEFAULT_PROPS.size },
       },
     },
     edge: {
-      options: EDGES,
       control: { type: "select" },
       table: {
-        type: { summary: docsEnum(EDGES) },
         defaultValue: { summary: DEFAULT_PROPS.edge },
       },
     },

--- a/src/components/Button/ActionButton.tsx
+++ b/src/components/Button/ActionButton.tsx
@@ -1,0 +1,82 @@
+import * as React from "react"
+import styled from "@emotion/styled"
+import { pxToRem } from "../ThemeProvider/typography"
+import {
+  ButtonRoot,
+  ButtonLinkRoot,
+  RESPONSIVE_SIZES,
+  DEFAULT_PROPS,
+} from "./Button"
+import type { ButtonStyleProps, ButtonSize } from "./Button"
+import type { LinkAdapterPropsOverrides } from "../LinkAdapter/LinkAdapter"
+
+type ActionButtonStyleProps = Omit<ButtonStyleProps, "startIcon" | "endIcon">
+type ActionButtonProps = ActionButtonStyleProps & React.ComponentProps<"button">
+
+const actionStyles = (size: ButtonSize) => {
+  return {
+    minWidth: "auto",
+    padding: 0,
+    height: {
+      small: "32px",
+      medium: "40px",
+      large: "48px",
+    }[size],
+    width: {
+      small: "32px",
+      medium: "40px",
+      large: "48px",
+    }[size],
+    "& svg, & .MuiSvgIcon-root": {
+      width: "1em",
+      height: "1em",
+      fontSize: pxToRem(
+        {
+          small: 20,
+          medium: 24,
+          large: 32,
+        }[size],
+      ),
+    },
+  }
+}
+/**
+ * A button that should contain a remixicon icon and nothing else.
+ * See [ActionButton docs](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs).
+ *
+ * See also:
+ * - [ActionButtonLink](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs#links)
+ * - [Button](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-button--docs) for text buttons
+ */
+const ActionButton = styled(
+  React.forwardRef<HTMLButtonElement, ActionButtonProps>(function (props, ref) {
+    return <ButtonRoot ref={ref} type="button" {...props} />
+  }),
+)(({ size = DEFAULT_PROPS.size, responsive, theme }) => {
+  return [
+    actionStyles(size),
+    responsive && {
+      [theme.breakpoints.down("sm")]: actionStyles(RESPONSIVE_SIZES[size]),
+    },
+  ]
+})
+ActionButton.displayName = "ActionButton"
+
+type ActionButtonLinkProps = ActionButtonStyleProps &
+  React.ComponentProps<"a"> & {
+    Component?: React.ElementType
+  } & LinkAdapterPropsOverrides
+
+/**
+ * See [ActionButtonLink docs](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs#links)
+ */
+const ActionButtonLink = ActionButton.withComponent(
+  ({ Component, ...props }: ActionButtonLinkProps) => {
+    return <ButtonLinkRoot Component={Component} {...props} />
+  },
+)
+ActionButtonLink.displayName = "ActionButtonLink"
+
+export { ActionButton, ActionButtonLink, DEFAULT_PROPS }
+
+export type { ActionButtonProps, ActionButtonLinkProps }

--- a/src/components/Button/ActionButton.tsx
+++ b/src/components/Button/ActionButton.tsx
@@ -49,9 +49,11 @@ const actionStyles = (size: ButtonSize) => {
  * - [Button](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-button--docs) for text buttons
  */
 const ActionButton = styled(
-  React.forwardRef<HTMLButtonElement, ActionButtonProps>(function (props, ref) {
-    return <ButtonRoot ref={ref} type="button" {...props} />
-  }),
+  React.forwardRef<HTMLButtonElement, ActionButtonProps>(
+    function Root(props, ref) {
+      return <ButtonRoot ref={ref} type="button" {...props} />
+    },
+  ),
 )(({ size = DEFAULT_PROPS.size, responsive, theme }) => {
   return [
     actionStyles(size),

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { Button, ButtonLink, DEFAULT_PROPS } from "./Button"
+import { Button, ButtonLink } from "./Button"
 import type { ButtonProps } from "./Button"
 import Grid from "@mui/material/Grid2"
 import Stack from "@mui/material/Stack"
@@ -12,7 +12,7 @@ import {
 } from "@remixicon/react"
 
 import { fn } from "@storybook/test"
-import { docsEnum, enumValues } from "@/story-utils"
+import { enumValues } from "@/story-utils"
 
 const ICONS = {
   None: undefined,
@@ -46,30 +46,6 @@ const meta: Meta<typeof Button> = {
   title: "smoot-design/Button",
   component: Button,
   argTypes: {
-    variant: {
-      options: VARIANTS,
-      control: { type: "select" },
-      table: {
-        type: { summary: docsEnum(VARIANTS) },
-        defaultValue: { summary: DEFAULT_PROPS.variant },
-      },
-    },
-    size: {
-      options: SIZES,
-      control: { type: "select" },
-      table: {
-        type: { summary: docsEnum(SIZES) },
-        defaultValue: { summary: DEFAULT_PROPS.size },
-      },
-    },
-    edge: {
-      options: ["circular", "rounded"],
-      control: { type: "select" },
-      table: {
-        type: { summary: docsEnum(EDGES) },
-        defaultValue: { summary: DEFAULT_PROPS.edge },
-      },
-    },
     startIcon: {
       options: Object.keys(ICONS),
       mapping: ICONS,
@@ -77,11 +53,6 @@ const meta: Meta<typeof Button> = {
     endIcon: {
       options: Object.keys(ICONS),
       mapping: ICONS,
-    },
-    responsive: {
-      table: {
-        defaultValue: { summary: DEFAULT_PROPS.responsive.toString() },
-      },
     },
   },
   args: {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -21,7 +21,7 @@ const ICONS = {
   TestTubeIcon: <RiTestTubeLine />,
 }
 
-const VARIANTS = enumValues<NonNullable<ButtonProps["variant"]>>({
+const VARIANTS = enumValues<ButtonProps["variant"]>({
   primary: true,
   secondary: true,
   tertiary: true,
@@ -31,12 +31,12 @@ const VARIANTS = enumValues<NonNullable<ButtonProps["variant"]>>({
   unstable_success: true,
 })
 const STABLE_VARIANTS = VARIANTS.filter((v) => !v.startsWith("unstable"))
-const SIZES = enumValues<NonNullable<ButtonProps["size"]>>({
+const SIZES = enumValues<ButtonProps["size"]>({
   small: true,
   medium: true,
   large: true,
 })
-const EDGES = enumValues<NonNullable<ButtonProps["edge"]>>({
+const EDGES = enumValues<ButtonProps["edge"]>({
   circular: true,
   rounded: true,
   none: true,

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,15 +1,18 @@
 import * as React from "react"
 import { render, screen } from "@testing-library/react"
 import { ThemeProvider, createTheme } from "../ThemeProvider/ThemeProvider"
-import { ButtonLink, ActionButtonLink } from "./Button"
+import { ButtonLink } from "./Button"
+import { ActionButtonLink } from "./ActionButton"
 
 const withLinkOverride = createTheme({
   custom: {
     LinkAdapter: React.forwardRef<HTMLAnchorElement, React.ComponentProps<"a">>(
-      (props, ref) => (
-        // eslint-disable-next-line jsx-a11y/anchor-has-content
-        <a ref={ref} data-custom="theme-default" {...props} />
-      ),
+      function LinkAdapter(props, ref) {
+        return (
+          // eslint-disable-next-line jsx-a11y/anchor-has-content
+          <a ref={ref} data-custom="theme-default" {...props} />
+        )
+      },
     ),
   },
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -24,7 +24,7 @@ type ButtonStyleProps = {
   size?: ButtonSize
   edge?: ButtonEdge
   /**
-   * Display an icon before the button text.
+   * Display an icon before the button text
    */
   startIcon?: React.ReactNode
   /**

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -52,7 +52,7 @@ const styleProps: Record<string, boolean> = {
   color: true,
 } satisfies Record<keyof ButtonStyleProps, boolean>
 
-const shouldForwardProp = (prop: string) => !styleProps[prop]
+const shouldForwardButtonProp = (prop: string) => !styleProps[prop]
 
 const DEFAULT_PROPS: Required<
   Omit<ButtonStyleProps, "startIcon" | "endIcon" | "color">
@@ -101,7 +101,7 @@ const sizeStyles = (
   ]
 }
 
-const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
+const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
   const { size, variant, edge, theme, color, responsive } = {
     ...DEFAULT_PROPS,
     ...props,
@@ -248,12 +248,12 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
   ])
 }
 
-const ButtonStyled = styled("button", { shouldForwardProp })<ButtonStyleProps>(
-  buildStyles,
-)
-const LinkStyled = styled(LinkAdapter, {
-  shouldForwardProp,
-})<ButtonStyleProps>(buildStyles)
+const ButtonRoot = styled("button", {
+  shouldForwardProp: shouldForwardButtonProp,
+})<ButtonStyleProps>(buttonStyles)
+const ButtonLinkRoot = styled(LinkAdapter, {
+  shouldForwardProp: shouldForwardButtonProp,
+})<ButtonStyleProps>(buttonStyles)
 
 const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
   ({ size, side }) => [
@@ -324,12 +324,13 @@ type ButtonProps = ButtonStyleProps & React.ComponentProps<"button">
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ children, ...props }, ref) => {
     return (
-      <ButtonStyled ref={ref} type="button" {...props}>
+      <ButtonRoot ref={ref} type="button" {...props}>
         <ButtonInner {...props}>{children}</ButtonInner>
-      </ButtonStyled>
+      </ButtonRoot>
     )
   },
 )
+Button.displayName = "Button"
 
 type ButtonLinkProps = ButtonStyleProps &
   React.ComponentProps<"a"> & {
@@ -342,87 +343,22 @@ type ButtonLinkProps = ButtonStyleProps &
 const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   ({ children, Component, ...props }: ButtonLinkProps, ref) => {
     return (
-      <LinkStyled Component={Component} ref={ref} {...props}>
+      <ButtonLinkRoot Component={Component} ref={ref} {...props}>
         <ButtonInner {...props}>{children}</ButtonInner>
-      </LinkStyled>
+      </ButtonLinkRoot>
     )
   },
 )
 
 ButtonLink.displayName = "ButtonLink"
 
-type ActionButtonStyleProps = Omit<ButtonStyleProps, "startIcon" | "endIcon">
-type ActionButtonProps = ActionButtonStyleProps & React.ComponentProps<"button">
-
-const actionStyles = (size: ButtonSize) => {
-  return {
-    minWidth: "auto",
-    padding: 0,
-    height: {
-      small: "32px",
-      medium: "40px",
-      large: "48px",
-    }[size],
-    width: {
-      small: "32px",
-      medium: "40px",
-      large: "48px",
-    }[size],
-    "& svg, & .MuiSvgIcon-root": {
-      width: "1em",
-      height: "1em",
-      fontSize: pxToRem(
-        {
-          small: 20,
-          medium: 24,
-          large: 32,
-        }[size],
-      ),
-    },
-  }
+export {
+  Button,
+  ButtonLink,
+  ButtonRoot,
+  DEFAULT_PROPS,
+  ButtonLinkRoot,
+  RESPONSIVE_SIZES,
 }
 
-/**
- * A button that should contain a remixicon icon and nothing else.
- * See [ActionButton docs](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs).
- *
- * See also:
- * - [ActionButtonLink](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-button--docs#links)
- * - [Button](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-button--docs) for text buttons
- */
-const ActionButton = styled(
-  React.forwardRef<HTMLButtonElement, ActionButtonProps>((props, ref) => (
-    <ButtonStyled ref={ref} type="button" {...props} />
-  )),
-)(({ size = DEFAULT_PROPS.size, responsive, theme }) => {
-  return [
-    actionStyles(size),
-    responsive && {
-      [theme.breakpoints.down("sm")]: actionStyles(RESPONSIVE_SIZES[size]),
-    },
-  ]
-})
-
-type ActionButtonLinkProps = ActionButtonStyleProps &
-  React.ComponentProps<"a"> & {
-    Component?: React.ElementType
-  } & LinkAdapterPropsOverrides
-
-/**
- * See [ActionButtonLink docs](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs#links)
- */
-const ActionButtonLink = ActionButton.withComponent(
-  ({ Component, ...props }: ButtonLinkProps) => {
-    return <LinkStyled Component={Component} {...props} />
-  },
-)
-ActionButtonLink.displayName = "ActionButtonLink"
-
-export { Button, ButtonLink, ActionButton, ActionButtonLink, DEFAULT_PROPS }
-
-export type {
-  ButtonProps,
-  ButtonLinkProps,
-  ActionButtonProps,
-  ActionButtonLinkProps,
-}
+export type { ButtonProps, ButtonLinkProps, ButtonStyleProps, ButtonSize }

--- a/src/components/LinkAdapter/LinkAdapter.tsx
+++ b/src/components/LinkAdapter/LinkAdapter.tsx
@@ -27,7 +27,7 @@ type LinkAdapterProps = React.ComponentProps<"a"> & {
  * - else, renders as `a` tag
  */
 const LinkAdapter = React.forwardRef<HTMLAnchorElement, LinkAdapterProps>(
-  ({ Component, ...props }, ref) => {
+  function LinkAdapter({ Component, ...props }, ref) {
     const theme = useTheme()
     const LinkComponent = Component ?? theme.custom.LinkAdapter
     return <PlainLink as={LinkComponent} ref={ref} {...props} />

--- a/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -18,6 +18,8 @@ const CustomLinkAdapater = React.forwardRef<
     {...props}
   />
 ))
+CustomLinkAdapater.displayName = "CustomLinkAdapter"
+
 const customTheme = createTheme({
   custom: {
     LinkAdapter: CustomLinkAdapater,

--- a/src/components/ThemeProvider/Typography.stories.tsx
+++ b/src/components/ThemeProvider/Typography.stories.tsx
@@ -8,6 +8,8 @@ import type { TypographyProps } from "@mui/material/Typography"
  * Typography styles can be controlled via the `theme.typography` object when
  * using the `styled` helper or via the `<Tyopgraphy variant="..." />` component.
  *
+ * For the `Typography` component, see [MUI's documentation](https://mui.com/material-ui/react-typography/).
+ *
  * ```tsx
  * const MyHeading = styled(({ theme }) => ({
  *   ...theme.typography.h2,
@@ -31,6 +33,7 @@ import type { TypographyProps } from "@mui/material/Typography"
 const meta: Meta<typeof Typography> = {
   title: "smoot-design/Typography",
   tags: ["autodocs"],
+  component: Typography,
 }
 
 export default meta

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,16 @@ export {
   createTheme,
 } from "./components/ThemeProvider/ThemeProvider"
 
+export { Button, ButtonLink } from "./components/Button/Button"
+export type { ButtonProps, ButtonLinkProps } from "./components/Button/Button"
+
 export {
-  Button,
-  ButtonLink,
   ActionButton,
   ActionButtonLink,
-} from "./components/Button/Button"
+} from "./components/Button/ActionButton"
+export type {
+  ActionButtonProps,
+  ActionButtonLinkProps,
+} from "./components/Button/ActionButton"
 
 export type { LinkAdapterPropsOverrides } from "./components/LinkAdapter/LinkAdapter"
-
-export type { ButtonProps, ButtonLinkProps } from "./components/Button/Button"

--- a/src/story-utils/index.ts
+++ b/src/story-utils/index.ts
@@ -3,8 +3,8 @@
  */
 const enumValues = <T extends string | undefined>(
   obj: Record<NonNullable<T>, unknown>,
-): T[] => {
-  return Object.keys(obj) as T[]
+): NonNullable<T>[] => {
+  return Object.keys(obj) as NonNullable<T>[]
 }
 
 export { enumValues }

--- a/src/story-utils/index.ts
+++ b/src/story-utils/index.ts
@@ -1,28 +1,10 @@
 /**
- * Generate a string that represents an enum of the keys of the given object.
- *
- * Example:
- * ```ts
- * const SIZES = {
- *   small: "irrelevant-value",
- *   large: "irrelevant-value",
- * }
- * console.log(docsEnum(SIZES))
- * // '"small" | "large"'
- *
- * ```
- *
- * Use case: Storybook docs are created with react-docgen, which fails to infer
- * typescript enum types.
- *
- *
+ * A type helper just to make sure an array contains union values.
  */
-const docsEnum = <T extends string>(values: T[]) => {
-  return values.map((key) => `"${key}"`).join(" | ")
-}
-
-const enumValues = <T extends string>(obj: Record<T, unknown>): T[] => {
+const enumValues = <T extends string | undefined>(
+  obj: Record<NonNullable<T>, unknown>,
+): T[] => {
   return Object.keys(obj) as T[]
 }
 
-export { docsEnum, enumValues }
+export { enumValues }


### PR DESCRIPTION
### What are the relevant tickets?
None, but did this as a separate PR on the way to https://github.com/mitodl/hq/issues/6192

### Description (What does it do?)
This switches Storybook's autodocs to use `react-docgen-typescript`, as described [here](https://storybook.js.org/docs/configure/integration/typescript#the-types-are-not-being-generated-for-my-component)

Why:
- `react-docgen` wasn't worked with styled components / emotion. This appears to be a [known, old issue](https://github.com/reactjs/react-docgen/issues/256) with `react-docgen`. 
- `react-docgen-typescript` handles enums automatically for us, and other types, too.

### How can this be tested?
1. Read the updated readme
2. Run `yarn storybook --docs` locally.
3. View http://localhost:6006/?path=/docs/smoot-design-button--docs ; the docs should look good and http://localhost:6006/?path=/docs/smoot-design-actionbutton--docs
4. Some other stuff you could try:
    - remove a union value from `ButtonSize`. The "argstable" in storybook docs should update
    - Update a jsdoc description in ButtonStyleProps ... the argstable should update
    - Update the jsdoc description above `Button`; the docs intro should update
