### PR TITLE
feat: add bordered variant for buttons

### DIFF
--- a/src/components/Button/ActionButton.stories.tsx
+++ b/src/components/Button/ActionButton.stories.tsx
@@ -24,6 +24,7 @@ const VARIANTS = enumValues<ActionButtonProps["variant"]>({
   primary: true,
   secondary: true,
   tertiary: true,
+  bordered: true,
   text: true,
   unstable_noBorder: true,
   unstable_inverted: true,
@@ -86,6 +87,9 @@ export const VariantsAndEdge: Story = {
         <ActionButton {...args} edge="none" variant="tertiary">
           {ICONS.DeleteIcon}
         </ActionButton>
+        <ActionButton {...args} edge="none" variant="bordered">
+          {ICONS.DeleteIcon}
+        </ActionButton>
         <ActionButton {...args} edge="none" variant="text">
           {ICONS.DeleteIcon}
         </ActionButton>
@@ -98,6 +102,9 @@ export const VariantsAndEdge: Story = {
           {ICONS.DeleteIcon}
         </ActionButton>
         <ActionButton {...args} edge="rounded" variant="tertiary">
+          {ICONS.DeleteIcon}
+        </ActionButton>
+        <ActionButton {...args} edge="rounded" variant="bordered">
           {ICONS.DeleteIcon}
         </ActionButton>
         <ActionButton {...args} edge="rounded" variant="text">
@@ -114,6 +121,9 @@ export const VariantsAndEdge: Story = {
         <ActionButton {...args} edge="circular" variant="tertiary">
           {ICONS.DeleteIcon}
         </ActionButton>
+        <ActionButton {...args} edge="circular" variant="bordered">
+          {ICONS.DeleteIcon}
+        </ActionButton>
         <ActionButton {...args} edge="circular" variant="text">
           {ICONS.DeleteIcon}
         </ActionButton>
@@ -121,6 +131,35 @@ export const VariantsAndEdge: Story = {
     </>
   ),
   tags: ["main"],
+}
+
+/**
+ * `ActionButtonLink` is styled as a `ActionButton` that renders an anchor tag.
+ *
+ * To use a custom link component (E.g. `Link` from `react-router` or `next/link`),
+ * pass it as the `Component` prop. Alternatively, customize the project-wide
+ * default link adapter via [Theme's LinkAdapter](../?path=/docs/smoot-design-themeprovider--docs)
+ */
+export const Links: Story = {
+  render: () => (
+    <Stack direction="row" gap={2} sx={{ my: 2 }}>
+      <ActionButtonLink href="#fake" variant="primary">
+        {ICONS.DeleteIcon}
+      </ActionButtonLink>
+      <ActionButtonLink href="#fake" variant="secondary">
+        {ICONS.DeleteIcon}
+      </ActionButtonLink>
+      <ActionButtonLink href="#fake" variant="tertiary">
+        {ICONS.DeleteIcon}
+      </ActionButtonLink>
+      <ActionButtonLink href="#fake" variant="bordered">
+        {ICONS.DeleteIcon}
+      </ActionButtonLink>
+      <ActionButtonLink href="#fake" variant="text">
+        {ICONS.DeleteIcon}
+      </ActionButtonLink>
+    </Stack>
+  ),
 }
 
 export const Showcase: Story = {
@@ -156,31 +195,5 @@ export const Showcase: Story = {
         )),
       )}
     </Grid>
-  ),
-}
-
-/**
- * `ActionButtonLink` is styled as a `ActionButton` that renders an anchor tag.
- *
- * To use a custom link component (E.g. `Link` from `react-router` or `next/link`),
- * pass it as the `Component` prop. Alternatively, customize the project-wide
- * default link adapter via [Theme's LinkAdapter](../?path=/docs/smoot-design-themeprovider--docs)
- */
-export const Links: Story = {
-  render: () => (
-    <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <ActionButtonLink href="#fake" variant="primary">
-        {ICONS.DeleteIcon}
-      </ActionButtonLink>
-      <ActionButtonLink href="#fake" variant="secondary">
-        {ICONS.DeleteIcon}
-      </ActionButtonLink>
-      <ActionButtonLink href="#fake" variant="tertiary">
-        {ICONS.DeleteIcon}
-      </ActionButtonLink>
-      <ActionButtonLink href="#fake" variant="text">
-        {ICONS.DeleteIcon}
-      </ActionButtonLink>
-    </Stack>
   ),
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -25,6 +25,7 @@ const VARIANTS = enumValues<ButtonProps["variant"]>({
   primary: true,
   secondary: true,
   tertiary: true,
+  bordered: true,
   text: true,
   unstable_noBorder: true,
   unstable_inverted: true,
@@ -77,6 +78,9 @@ export const VariantsAndEdge: Story = {
         <Button edge="none" variant="tertiary" {...args}>
           Tertiary
         </Button>
+        <Button edge="none" variant="bordered" {...args}>
+          Bordered
+        </Button>
         <Button edge="none" variant="text" {...args}>
           Text
         </Button>
@@ -91,6 +95,9 @@ export const VariantsAndEdge: Story = {
         <Button edge="rounded" variant="tertiary" {...args}>
           Tertiary
         </Button>
+        <Button edge="rounded" variant="bordered" {...args}>
+          Bordered
+        </Button>
         <Button edge="rounded" variant="text" {...args}>
           Text
         </Button>
@@ -104,6 +111,9 @@ export const VariantsAndEdge: Story = {
         </Button>
         <Button edge="circular" variant="tertiary" {...args}>
           Tertiary
+        </Button>
+        <Button edge="circular" variant="bordered" {...args}>
+          Bordered
         </Button>
         <Button edge="circular" variant="text" {...args}>
           Text
@@ -191,6 +201,9 @@ export const Links: Story = {
         Link
       </ButtonLink>
       <ButtonLink href="#fake" variant="tertiary">
+        Link
+      </ButtonLink>
+      <ButtonLink href="#fake" variant="bordered">
         Link
       </ButtonLink>
       <ButtonLink href="#fake" variant="text">

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,6 +13,7 @@ type ButtonVariant =
   | "secondary"
   | "tertiary"
   | "text"
+  | "bordered"
   | "unstable_noBorder"
   | "unstable_inverted"
   | "unstable_success"
@@ -107,7 +108,7 @@ const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
     ...props,
   }
   const { colors } = theme.custom
-  const hasBorder = variant === "secondary"
+  const hasBorder = variant === "secondary" || variant === "bordered"
   return css([
     {
       color: theme.palette.text.primary,
@@ -151,11 +152,6 @@ const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
         boxShadow: "none",
       },
     },
-    hasBorder && {
-      backgroundColor: "transparent",
-      borderColor: "currentcolor",
-      borderStyle: "solid",
-    },
     variant === "unstable_success" && {
       backgroundColor: colors.darkGreen,
       color: colors.white,
@@ -172,13 +168,11 @@ const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
         boxShadow: "none",
       },
     },
-    hasBorder && {
+    variant === "secondary" && {
+      color: colors.red,
       backgroundColor: "transparent",
       borderColor: "currentcolor",
       borderStyle: "solid",
-    },
-    variant === "secondary" && {
-      color: colors.red,
       ":hover:not(:disabled)": {
         // brightRed at 0.06 alpha
         backgroundColor: "rgba(255, 20, 35, 0.06)",
@@ -197,6 +191,20 @@ const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
       },
       ":disabled": {
         color: colors.silverGray,
+      },
+    },
+    variant === "bordered" && {
+      backgroundColor: colors.white,
+      color: colors.silverGrayDark,
+      border: `1px solid ${colors.silverGrayLight}`,
+      ":hover:not(:disabled)": {
+        backgroundColor: colors.lightGray1,
+        color: colors.darkGray2,
+      },
+      ":disabled": {
+        backgroundColor: colors.lightGray2,
+        border: `1px solid ${colors.lightGray2}`,
+        color: colors.silverGrayDark,
       },
     },
     variant === "unstable_noBorder" && {


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/6279

### Description (What does it do?)
Adds the "bordered" button variant, introduced in MIT Learn in https://github.com/mitodl/mit-learn/pull/1900

### How can this be tested?
With the repo set up (just `yarn install`)
1. Run `yarn start` to start storybook.
2. View the new bordered button variant
    - http://localhost:6006/?path=/docs/smoot-design-button--docs
    - http://localhost:6006/?path=/docs/smoot-design-actionbutton--docs
3. ☝️ should look the same as the "bordered" variant at https://mitodl.github.io/mit-learn/?path=/story/smoot-design-button--variant-story
