### PR TITLE
feat: Webspclet-based AI chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@mui/system": "^6.1.6",
     "@remixicon/react": "^4.2.0",
     "@types/jest": "^29.5.14",
-    "ai": "^4.0.13",
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react-markdown": "^9.0.1",

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,2 +1,3 @@
 export { AiChat } from "./components/AiChat/AiChat"
 export type { AiChatProps } from "./components/AiChat/AiChat"
+export { AiChatWs } from "./components/AiChat/AiChatWs"

--- a/src/components/AiChat/AiChat.mdx
+++ b/src/components/AiChat/AiChat.mdx
@@ -12,6 +12,9 @@ for use with AI services. It can be used with text-streaming or JSON APIs.
 
 This demo shows the AiChat component with a simple text-streaming API.
 
+A compoonent `AiChatWs` is available for websocket connections and has the same
+props, excluding `requestOptions.fetchOptions`.
+
 <Primary />
 
 ## Inputs

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -4,7 +4,7 @@ import Skeleton from "@mui/material/Skeleton"
 import { Input } from "../Input/Input"
 import { ActionButton } from "../Button/ActionButton"
 import { RiSendPlaneFill } from "@remixicon/react"
-import { useAiChat } from "./utils"
+import { useHttpChat } from "./utils"
 import Markdown from "react-markdown"
 
 import type { AiChatProps } from "./types"
@@ -141,7 +141,8 @@ const AiChat: React.FC<AiChatProps> = function AiChat({
     handleSubmit,
     append,
     isLoading,
-  } = useAiChat(requestOpts, {
+    isResponding,
+  } = useHttpChat(requestOpts, {
     initialMessages: initialMessages,
   })
 
@@ -155,9 +156,6 @@ const AiChat: React.FC<AiChatProps> = function AiChat({
       return m
     })
   }, [parseContent, unparsed, initialMessages])
-
-  const waiting =
-    !showStarters && messages[messages.length - 1]?.role === "user"
 
   const scrollToBottom = () => {
     messagesRef.current?.scrollBy({
@@ -204,7 +202,7 @@ const AiChat: React.FC<AiChatProps> = function AiChat({
             ))}
           </StarterContainer>
         ) : null}
-        {waiting ? (
+        {isLoading && !isResponding ? (
           <MessageRow key={"loading"}>
             <Avatar className={classes.avatar} />
             <Message>

--- a/src/components/AiChat/AiChatDisplay.tsx
+++ b/src/components/AiChat/AiChatDisplay.tsx
@@ -1,0 +1,227 @@
+import * as React from "react"
+import styled from "@emotion/styled"
+import Skeleton from "@mui/material/Skeleton"
+import { Input } from "../Input/Input"
+import { ActionButton } from "../Button/ActionButton"
+import { RiSendPlaneFill } from "@remixicon/react"
+import { useAiChatContext } from "./ChatContext"
+import Markdown from "react-markdown"
+
+import type { AiChatProps } from "./types"
+import { ScrollSnap } from "../ScrollSnap/ScrollSnap"
+import classNames from "classnames"
+import { SrAnnouncer } from "../SrAnnouncer/SrAnnouncer"
+
+const ChatContainer = styled.div(({ theme }) => ({
+  width: "100%",
+  height: "100%",
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  backgroundColor: theme.custom.colors.lightGray1,
+  display: "flex",
+  flexDirection: "column",
+}))
+
+const MessagesContainer = styled(ScrollSnap)({
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  padding: "24px",
+  paddingBottom: "0px",
+  overflow: "auto",
+})
+const MessageRow = styled.div<{
+  reverse?: boolean
+}>(({ reverse }) => [
+  {
+    margin: "8px 0",
+    display: "flex",
+    width: "100%",
+    flexDirection: reverse ? "row-reverse" : "row",
+  },
+])
+const Avatar = styled.div({})
+const Message = styled.div(({ theme }) => ({
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  backgroundColor: theme.custom.colors.white,
+  borderRadius: "24px",
+  padding: "4px 16px",
+  ...theme.typography.body2,
+  "p:first-of-type": {
+    marginTop: 0,
+  },
+  "p:last-of-type": {
+    marginBottom: 0,
+  },
+  a: {
+    color: theme.custom.colors.mitRed,
+    textDecoration: "none",
+  },
+  "a:hover": {
+    color: theme.custom.colors.red,
+    textDecoration: "underline",
+  },
+}))
+
+const StarterContainer = styled.div({
+  alignSelf: "flex-end",
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+})
+const Starter = styled.button(({ theme }) => ({
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  backgroundColor: theme.custom.colors.white,
+  borderRadius: "24px",
+  padding: "4px 16px",
+  ...theme.typography.body2,
+  cursor: "pointer",
+  "&:hover": {
+    backgroundColor: theme.custom.colors.lightGray1,
+  },
+}))
+
+const Controls = styled.div(({ theme }) => ({
+  display: "flex",
+  justifyContent: "space-around",
+  padding: "12px 24px",
+  backgroundColor: theme.custom.colors.white,
+}))
+const Form = styled.form(() => ({
+  display: "flex",
+  width: "80%",
+  gap: "12px",
+  alignItems: "center",
+}))
+
+const DotsContainer = styled.span(({ theme }) => ({
+  display: "inline-flex",
+  gap: "4px",
+  ".MuiSkeleton-root": {
+    backgroundColor: theme.custom.colors.silverGray,
+  },
+}))
+const Dots = () => {
+  return (
+    <DotsContainer>
+      <Skeleton variant="circular" width="8px" height="8px" />
+      <Skeleton variant="circular" width="8px" height="8px" />
+      <Skeleton variant="circular" width="8px" height="8px" />
+    </DotsContainer>
+  )
+}
+
+const classes = {
+  root: "MitAiChat--root",
+  conversationStarter: "MitAiChat--conversationStarter",
+  messagesContainer: "MitAiChat--messagesContainer",
+  messageRow: "MitAiChat--messageRow",
+  message: "MitAiChat--message",
+  avatar: "MitAiChat--avatar",
+  input: "MitAiChat--input",
+}
+
+const AiChatDisplay: React.FC<
+  Pick<AiChatProps, "className" | "conversationStarters" | "srLoadingMessages">
+> = function AiChat({ className, conversationStarters, srLoadingMessages }) {
+  const [showStarters, setShowStarters] = React.useState(true)
+  const messagesRef = React.useRef<HTMLDivElement>(null)
+  const {
+    messages,
+    input,
+    handleInputChange,
+    handleSubmit,
+    append,
+    isLoading,
+    isResponding,
+  } = useAiChatContext()
+
+  const scrollToBottom = () => {
+    messagesRef.current?.scrollBy({
+      behavior: "instant",
+      top: messagesRef.current.scrollHeight,
+    })
+  }
+
+  const lastMsg = messages[messages.length - 1]
+
+  return (
+    <ChatContainer className={classNames(className, classes.root)}>
+      <MessagesContainer
+        className={classes.messagesContainer}
+        ref={messagesRef}
+      >
+        {messages.map((m) => (
+          <MessageRow
+            key={m.id}
+            reverse={m.role === "user"}
+            data-chat-role={m.role}
+            className={classes.messageRow}
+          >
+            <Avatar />
+            <Message className={classes.message}>
+              <Markdown>{m.content}</Markdown>
+            </Message>
+          </MessageRow>
+        ))}
+        {showStarters ? (
+          <StarterContainer>
+            {conversationStarters?.map((m) => (
+              <Starter
+                className={classes.conversationStarter}
+                key={m.content}
+                onClick={() => {
+                  setShowStarters(false)
+                  scrollToBottom()
+                  append({ role: "user", content: m.content })
+                }}
+              >
+                {m.content}
+              </Starter>
+            ))}
+          </StarterContainer>
+        ) : null}
+        {isLoading && !isResponding ? (
+          <MessageRow key={"loading"}>
+            <Avatar className={classes.avatar} />
+            <Message>
+              <Dots />
+            </Message>
+          </MessageRow>
+        ) : null}
+      </MessagesContainer>
+      <Controls>
+        <Form
+          onSubmit={(e) => {
+            setShowStarters(false)
+            scrollToBottom()
+            handleSubmit(e)
+          }}
+        >
+          <Input
+            className={classes.input}
+            placeholder="Type a message..."
+            name="message"
+            sx={{ flex: 1 }}
+            value={input}
+            onChange={handleInputChange}
+          />
+          <ActionButton
+            aria-label="Send"
+            type="submit"
+            disabled={isLoading || !input}
+          >
+            <RiSendPlaneFill />
+          </ActionButton>
+        </Form>
+      </Controls>
+      <SrAnnouncer
+        isLoading={isLoading}
+        loadingMessages={srLoadingMessages}
+        message={lastMsg.role === "assistant" ? lastMsg.content : ""}
+      />
+    </ChatContainer>
+  )
+}
+
+export { AiChatDisplay }
+export type { AiChatProps }

--- a/src/components/AiChat/AiChatWs.tsx
+++ b/src/components/AiChat/AiChatWs.tsx
@@ -1,11 +1,11 @@
 import * as React from "react"
 import { AiChatDisplay } from "./AiChatDisplay"
-import { AiChatHttpProvider } from "./ChatContextHttp"
+import { AiChatWsProvider } from "./ChatContextWs"
 import type { AiChatProps } from "./types"
 
-const AiChat: React.FC<AiChatProps> = (props) => {
+const AiChatWs: React.FC<AiChatProps> = (props) => {
   return (
-    <AiChatHttpProvider
+    <AiChatWsProvider
       initialMessages={props.initialMessages}
       requestOpts={props.requestOpts}
       parseContent={props.parseContent}
@@ -15,9 +15,8 @@ const AiChat: React.FC<AiChatProps> = (props) => {
         conversationStarters={props.conversationStarters}
         className={props.className}
       />
-    </AiChatHttpProvider>
+    </AiChatWsProvider>
   )
 }
 
-export { AiChat }
-export type { AiChatProps }
+export { AiChatWs }

--- a/src/components/AiChat/ChatContext.tsx
+++ b/src/components/AiChat/ChatContext.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import type { ChatMessage, CreateMessage } from "./types"
+
+type AiChatUtils = {
+  initialMessages: ChatMessage[]
+  messages: ChatMessage[]
+  isLoading: boolean
+  isResponding: boolean
+  input: string
+  handleInputChange: React.ChangeEventHandler<HTMLInputElement>
+  handleSubmit: React.FormEventHandler<HTMLFormElement>
+  append: (message: ChatMessage | CreateMessage) => Promise<void>
+}
+
+const AiChatContext = React.createContext<AiChatUtils | undefined>(undefined)
+
+const useAiChatContext = (): AiChatUtils => {
+  const context = React.useContext(AiChatContext)
+  if (!context) {
+    throw new Error("useChatContext must be used within a ChatProvider")
+  }
+  return context
+}
+
+export { AiChatContext, useAiChatContext }
+export type { AiChatUtils }

--- a/src/components/AiChat/ChatContextHttp.tsx
+++ b/src/components/AiChat/ChatContextHttp.tsx
@@ -1,0 +1,116 @@
+import type { RequestOpts, ChatMessage, CreateMessage } from "./types"
+import * as React from "react"
+import { useId, useState } from "react"
+import { AiChatContext, type AiChatUtils } from "./ChatContext"
+import invariant from "tiny-invariant"
+
+const identity = <T,>(x: T): T => x
+
+type ChatOptions = {
+  requestOpts: RequestOpts
+  initialMessages: CreateMessage[]
+  parseContent?: (content: unknown) => string
+}
+
+const useHttpChat = ({
+  requestOpts,
+  initialMessages: initMsgs = [],
+  parseContent,
+}: ChatOptions): AiChatUtils => {
+  const prefix = useId()
+  const initialMessages = React.useMemo(() => {
+    return initMsgs.map((m, i) => ({ ...m, id: `initial-${prefix}-${i}` }))
+  }, [initMsgs, prefix])
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isResponding, setIsResponding] = useState<boolean>(false)
+  const [input, setInput] = useState<string>("")
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    setInput(e.target.value)
+  }
+
+  const transformBody = requestOpts.transformBody ?? identity
+  const getResponse = async (message: ChatMessage | CreateMessage) => {
+    if (isLoading || isResponding) return
+    setIsLoading(true)
+    const fullMessage: ChatMessage = {
+      id: `${prefix}-${messages.length}`,
+      ...message,
+    }
+    const allMessages: ChatMessage[] = [...messages, fullMessage]
+    setMessages(allMessages)
+
+    await fetch(requestOpts.apiUrl, {
+      method: "POST",
+      body: JSON.stringify(transformBody(allMessages)),
+      ...requestOpts.fetchOpts,
+      headers: {
+        "Content-Type": "application/json",
+        ...requestOpts.fetchOpts?.headers,
+      },
+    }).then(async (response) => {
+      const reader = response.body?.getReader()
+      invariant(reader, "Expected response body to be readable.")
+      const textDecoder = new TextDecoder()
+
+      setIsResponding(true)
+      const respnseMsg: ChatMessage = {
+        id: `${prefix}-${allMessages.length}`,
+        content: "",
+        role: "assistant",
+      }
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) {
+          setIsResponding(false)
+          setIsLoading(false)
+          break
+        }
+
+        const chunk = textDecoder.decode(value)
+
+        if (chunk) {
+          const parsed = parseContent ? parseContent(chunk) : chunk
+          respnseMsg.content += parsed
+          setMessages([
+            ...allMessages,
+            { ...respnseMsg, content: respnseMsg.content },
+          ])
+        }
+      }
+    })
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
+    setInput("")
+    getResponse({ content: input, role: "user" })
+  }
+
+  return {
+    initialMessages,
+    messages,
+    isLoading,
+    isResponding,
+    input,
+    handleInputChange,
+    handleSubmit,
+    append: getResponse,
+  }
+}
+
+const AiChatHttpProvider: React.FC<
+  ChatOptions & {
+    children: React.ReactNode
+  }
+> = (props) => {
+  const value = useHttpChat(props)
+  return (
+    <AiChatContext.Provider value={value}>
+      {props.children}
+    </AiChatContext.Provider>
+  )
+}
+
+export { AiChatHttpProvider }

--- a/src/components/AiChat/ChatContextWs.tsx
+++ b/src/components/AiChat/ChatContextWs.tsx
@@ -1,0 +1,123 @@
+import type { RequestOpts, ChatMessage, CreateMessage } from "./types"
+import * as React from "react"
+import { useId, useRef, useState } from "react"
+import type { AiChatUtils } from "./ChatContext"
+import { AiChatContext } from "./ChatContext"
+
+const identity = <T,>(x: T): T => x
+
+type ChatOptions = {
+  requestOpts: RequestOpts
+  initialMessages: CreateMessage[]
+  parseContent?: (content: unknown) => string
+}
+
+const useWebSocketChat = ({
+  requestOpts,
+  initialMessages: initMsgs = [],
+  parseContent,
+}: ChatOptions): AiChatUtils => {
+  const prefix = useId()
+  const initialMessages = React.useMemo(() => {
+    return initMsgs.map((m, i) => ({ ...m, id: `initial-${prefix}-${i}` }))
+  }, [initMsgs, prefix])
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isResponding, setIsResponding] = useState<boolean>(false)
+  const wsRef = useRef<WebSocket | null>(null)
+  const getWs = () => {
+    // Based on https://github.com/facebook/react/issues/14490#issuecomment-454973512
+    // to ensure the ws onconnect is attached immediately
+    // and no extra sockets are created.
+    if (
+      wsRef.current?.url !== requestOpts.apiUrl ||
+      wsRef.current?.readyState === wsRef.current?.CLOSED
+    ) {
+      wsRef.current = new WebSocket(requestOpts.apiUrl)
+      wsRef.current.addEventListener("message", (e) => {
+        setIsLoading(false)
+        const text: string = parseContent ? parseContent(e.data) : e.data
+        if (text === "!endResponse") {
+          setIsResponding(false)
+          return
+        }
+        setIsResponding(true)
+        setMessages((prev) => {
+          const last = prev[prev.length - 1]
+          if (last.role === "assistant") {
+            return [
+              ...prev.slice(0, -1),
+              { ...last, content: last.content + text },
+            ]
+          } else {
+            return [
+              ...prev,
+              {
+                id: `${prefix}-${prev.length}`,
+                content: text,
+                role: "assistant",
+              },
+            ]
+          }
+        })
+      })
+    }
+    return wsRef.current
+  }
+
+  const [input, setInput] = useState<string>("")
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    setInput(e.target.value)
+  }
+
+  const transformBody = requestOpts.transformBody ?? identity
+  const getResponse = async (message: ChatMessage | CreateMessage) => {
+    if (isLoading || isResponding) return
+    setIsLoading(true)
+    const allMessages = [
+      ...messages,
+      { id: `${prefix}-${messages.length}`, ...message },
+    ]
+    setMessages(allMessages)
+    const ws = getWs()
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify(transformBody(allMessages)))
+    } else {
+      ws.addEventListener("open", () => {
+        ws.send(JSON.stringify(transformBody(allMessages)))
+      })
+    }
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
+    setInput("")
+    getResponse({ content: input, role: "user" })
+  }
+
+  return {
+    initialMessages,
+    messages,
+    isLoading,
+    isResponding,
+    input,
+    handleInputChange,
+    handleSubmit,
+    append: getResponse,
+  }
+}
+
+const AiChatWsProvider: React.FC<
+  ChatOptions & {
+    children: React.ReactNode
+  }
+> = (props) => {
+  const value = useWebSocketChat(props)
+  return (
+    <AiChatContext.Provider value={value}>
+      {props.children}
+    </AiChatContext.Provider>
+  )
+}
+
+export { AiChatWsProvider }

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -1,11 +1,10 @@
-// Some of these are based on (compatible, but simplfied / restricted) versions of ai/react types.
-
 type Role = "assistant" | "user"
 type ChatMessage = {
   id: string
   content: string
   role: Role
 }
+type CreateMessage = Omit<ChatMessage, "id">
 
 type RequestOpts = {
   apiUrl: string
@@ -45,4 +44,4 @@ type AiChatProps = {
   }[]
 }
 
-export type { RequestOpts, AiChatProps, ChatMessage }
+export type { RequestOpts, AiChatProps, ChatMessage, CreateMessage }

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -18,13 +18,8 @@ type RequestOpts = {
   /**
    * Extra options to pass to fetch.
    *
-   * If headers are specified, they will override the headersOpts.
    */
   fetchOpts?: RequestInit
-  /**
-   * Extra headers to pass to fetch.
-   */
-  headersOpts?: HeadersInit
 }
 
 type AiChatProps = {

--- a/src/components/AiChat/utils.ts
+++ b/src/components/AiChat/utils.ts
@@ -1,8 +1,18 @@
 import type { RequestOpts, ChatMessage, CreateMessage } from "./types"
-import { useId, useState } from "react"
+import { useId, useRef, useState } from "react"
 import invariant from "tiny-invariant"
 
 const identity = <T>(x: T): T => x
+
+type ChatContext = {
+  messages: ChatMessage[]
+  isLoading: boolean
+  isResponding: boolean
+  input: string
+  handleInputChange: React.ChangeEventHandler<HTMLInputElement>
+  handleSubmit: React.FormEventHandler<HTMLFormElement>
+  append: (message: ChatMessage | CreateMessage) => Promise<void>
+}
 
 const useHttpChat = (
   requestOpts: RequestOpts,
@@ -11,7 +21,7 @@ const useHttpChat = (
   } = {
     initialMessages: [],
   },
-) => {
+): ChatContext => {
   const prefix = useId()
   const [messages, setMessages] = useState<ChatMessage[]>(opts.initialMessages)
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -36,10 +46,9 @@ const useHttpChat = (
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...requestOpts.headersOpts,
+        ...requestOpts.fetchOpts?.headers,
       },
       body: JSON.stringify(transformBody(allMessages)),
-      ...requestOpts.fetchOpts,
     }).then(async (response) => {
       const reader = response.body?.getReader()
       invariant(reader, "Expected response body to be readable.")
@@ -90,4 +99,98 @@ const useHttpChat = (
   }
 }
 
-export { useHttpChat }
+const useWebSocketChat = (
+  requestOpts: RequestOpts,
+  opts: {
+    initialMessages: ChatMessage[]
+  } = {
+    initialMessages: [],
+  },
+): ChatContext => {
+  const prefix = useId()
+  const [messages, setMessages] = useState<ChatMessage[]>(opts.initialMessages)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isResponding, setIsResponding] = useState<boolean>(false)
+  const wsRef = useRef<WebSocket | null>(null)
+  const getWs = () => {
+    // Based on https://github.com/facebook/react/issues/14490#issuecomment-454973512
+    // to ensure the ws onconnect is attached immediately
+    // and no extra sockets are created.
+    if (
+      wsRef.current?.url !== requestOpts.apiUrl ||
+      wsRef.current?.readyState === wsRef.current?.CLOSED
+    ) {
+      wsRef.current = new WebSocket(requestOpts.apiUrl)
+      wsRef.current.onmessage = (event) => {
+        setIsLoading(false)
+        const text: string = event.data
+        if (text === "!endResponse") {
+          setIsResponding(false)
+          return
+        }
+        setIsResponding(true)
+        setMessages((prev) => {
+          const last = prev[prev.length - 1]
+          if (last.role === "assistant") {
+            return [
+              ...prev.slice(0, -1),
+              { ...last, content: last.content + text },
+            ]
+          } else {
+            return [
+              ...prev,
+              {
+                id: `${prefix}-${prev.length}`,
+                content: text,
+                role: "assistant",
+              },
+            ]
+          }
+        })
+      }
+    }
+    return wsRef.current
+  }
+
+  const [input, setInput] = useState<string>("")
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    setInput(e.target.value)
+  }
+
+  const transformBody = requestOpts.transformBody ?? identity
+  const getResponse = async (message: ChatMessage | CreateMessage) => {
+    if (isLoading || isResponding) return
+    setIsLoading(true)
+    const allMessages = [
+      ...messages,
+      { id: `${prefix}-${messages.length}`, ...message },
+    ]
+    setMessages(allMessages)
+    const ws = getWs()
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify(transformBody(allMessages)))
+    } else {
+      ws.addEventListener("open", () => {
+        ws.send(JSON.stringify(transformBody(allMessages)))
+      })
+    }
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
+    setInput("")
+    getResponse({ content: input, role: "user" })
+  }
+
+  return {
+    messages,
+    isLoading,
+    isResponding,
+    input,
+    handleInputChange,
+    handleSubmit,
+    append: getResponse,
+  }
+}
+
+export { useHttpChat, useWebSocketChat }

--- a/src/jsdom-extended.ts
+++ b/src/jsdom-extended.ts
@@ -10,6 +10,7 @@ class JSDOMEnvironmentExtended extends TestEnvironment {
     this.global.ReadableStream = ReadableStream
     this.global.Response = Response
     this.global.TextDecoderStream = TextDecoderStream
+    this.global.TextDecoder = TextDecoder
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,68 +12,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@ai-sdk/provider-utils@npm:2.0.3"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.0.1"
-    eventsource-parser: "npm:^3.0.0"
-    nanoid: "npm:^3.3.7"
-    secure-json-parse: "npm:^2.7.0"
-  peerDependencies:
-    zod: ^3.0.0
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: 10/16f1876f0884ccd6ccd2b0de63bac16f89d19122d74d1ec3db1169cfadf0d5ddbae347ff8944648efa8899653ff722451ea36f0894dbf995af5c1a5ea39d19dc
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/provider@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@ai-sdk/provider@npm:1.0.1"
-  dependencies:
-    json-schema: "npm:^0.4.0"
-  checksum: 10/bdcffb0475a021e17065f9161fcf0d171490c23a27162f400b57e0dfcd895e2bf25f94faff044e1faefca0811e3d1f5ca3209d577485f2f27bd21491531d57fc
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/react@npm:1.0.5":
-  version: 1.0.5
-  resolution: "@ai-sdk/react@npm:1.0.5"
-  dependencies:
-    "@ai-sdk/provider-utils": "npm:2.0.3"
-    "@ai-sdk/ui-utils": "npm:1.0.4"
-    swr: "npm:^2.2.5"
-    throttleit: "npm:2.1.0"
-  peerDependencies:
-    react: ^18 || ^19 || ^19.0.0-rc
-    zod: ^3.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    zod:
-      optional: true
-  checksum: 10/58be5694c75d862b485a561f62fe915b9ba57b14aaa73fd0d6d9ecbf097ceb325475f69cef741bfd706e281a8aef97f5510b3ed106e6358055707a5803d7e910
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/ui-utils@npm:1.0.4":
-  version: 1.0.4
-  resolution: "@ai-sdk/ui-utils@npm:1.0.4"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.0.1"
-    "@ai-sdk/provider-utils": "npm:2.0.3"
-    zod-to-json-schema: "npm:^3.23.5"
-  peerDependencies:
-    zod: ^3.0.0
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: 10/d9b13bc954fa917401eb9d8ca5a66ff695f000177584e64d9864ac03b951cdc6ad66103a0db34191a55cb4ee8fc7a61d03658cc3d07b989cd9c0eb40c677a00c
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -2582,7 +2520,6 @@ __metadata:
     "@types/react-dom": "npm:^19.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.13.0"
     "@typescript-eslint/typescript-estree": "npm:^8.13.0"
-    ai: "npm:^4.0.13"
     classnames: "npm:^2.5.1"
     conventional-changelog-conventionalcommits: "npm:^8.0.0"
     eslint: "npm:8.57.1"
@@ -3465,13 +3402,6 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^22.2.0"
   checksum: 10/9ea6189839439e1085799cc16ee699292538d9c14dd15e9e45462377287f863b6be93455d2ad9acffd561018a0c35adbb9d1437e92075c9058d6c6d69ff2f503
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/api@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0"
-  checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
   languageName: node
   linkType: hard
 
@@ -4759,13 +4689,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/diff-match-patch@npm:^1.0.36":
-  version: 1.0.36
-  resolution: "@types/diff-match-patch@npm:1.0.36"
-  checksum: 10/7d7ce03422fcc3e79d0cda26e4748aeb176b75ca4b4e5f38459b112bf24660d628424bdb08d330faefa69039d19a5316e7a102a8ab68b8e294c8346790e55113
-  languageName: node
-  linkType: hard
-
 "@types/doctrine@npm:^0.0.9":
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
@@ -5652,29 +5575,6 @@ __metadata:
     clean-stack: "npm:^5.2.0"
     indent-string: "npm:^5.0.0"
   checksum: 10/37834eb0dac6ebd05ca8aa82e00deeb65fb7b1462c68ccb620221ba1753640fcb249e46c03401b470701a58826b65426deda83783fc2e8347c4b5037b2724d9b
-  languageName: node
-  linkType: hard
-
-"ai@npm:^4.0.13":
-  version: 4.0.13
-  resolution: "ai@npm:4.0.13"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.0.1"
-    "@ai-sdk/provider-utils": "npm:2.0.3"
-    "@ai-sdk/react": "npm:1.0.5"
-    "@ai-sdk/ui-utils": "npm:1.0.4"
-    "@opentelemetry/api": "npm:1.9.0"
-    jsondiffpatch: "npm:0.6.0"
-    zod-to-json-schema: "npm:^3.23.5"
-  peerDependencies:
-    react: ^18 || ^19 || ^19.0.0-rc
-    zod: ^3.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    zod:
-      optional: true
-  checksum: 10/5860ad6c03df566358fa84c472f95417b5558fee5ed9c9f71a44b9026943ac5d147c5c8523eea7d94719030946616734f4c695666d0288d515b83de04c2d7a1f
   languageName: node
   linkType: hard
 
@@ -6905,7 +6805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"client-only@npm:0.0.1, client-only@npm:^0.0.1":
+"client-only@npm:0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
   checksum: 10/0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
@@ -7649,13 +7549,6 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
-  languageName: node
-  linkType: hard
-
-"diff-match-patch@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "diff-match-patch@npm:1.0.5"
-  checksum: 10/fd1ab417eba9559bda752a4dfc9a8ac73fa2ca8b146d29d153964b437168e301c09d8a688fae0cd81d32dc6508a4918a94614213c85df760793f44e245173bb6
   languageName: node
   linkType: hard
 
@@ -8745,13 +8638,6 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
-  languageName: node
-  linkType: hard
-
-"eventsource-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "eventsource-parser@npm:3.0.0"
-  checksum: 10/8215adf5d8404105ecd0658030b0407e06987ceb9aadcea28a38d69bacf02e5d0fc8bba5fa7c3954552c89509c8ef5e1fa3895e000c061411c055b4bbc26f4b0
   languageName: node
   linkType: hard
 
@@ -11309,13 +11195,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "json-schema@npm:0.4.0"
-  checksum: 10/8b3b64eff4a807dc2a3045b104ed1b9335cd8d57aa74c58718f07f0f48b8baa3293b00af4dcfbdc9144c3aafea1e97982cc27cc8e150fc5d93c540649507a458
-  languageName: node
-  linkType: hard
-
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -11354,19 +11233,6 @@ __metadata:
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
-  languageName: node
-  linkType: hard
-
-"jsondiffpatch@npm:0.6.0":
-  version: 0.6.0
-  resolution: "jsondiffpatch@npm:0.6.0"
-  dependencies:
-    "@types/diff-match-patch": "npm:^1.0.36"
-    chalk: "npm:^5.3.0"
-    diff-match-patch: "npm:^1.0.5"
-  bin:
-    jsondiffpatch: bin/jsondiffpatch.js
-  checksum: 10/124b9797c266c693e69f8d23216e64d5ca4b21a4ec10e3a769a7b8cb19602ba62522f9a3d0c55299c1bfbe5ad955ca9ad2852439ca2c6b6316b8f91a5c218e94
   languageName: node
   linkType: hard
 
@@ -15171,13 +15037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "secure-json-parse@npm:2.7.0"
-  checksum: 10/974386587060b6fc5b1ac06481b2f9dbbb0d63c860cc73dc7533f27835fdb67b0ef08762dbfef25625c15bc0a0c366899e00076cb0d556af06b71e22f1dede4c
-  languageName: node
-  linkType: hard
-
 "semantic-release@npm:^24.2.0":
   version: 24.2.0
   resolution: "semantic-release@npm:24.2.0"
@@ -16097,18 +15956,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swr@npm:^2.2.5":
-  version: 2.2.5
-  resolution: "swr@npm:2.2.5"
-  dependencies:
-    client-only: "npm:^0.0.1"
-    use-sync-external-store: "npm:^1.2.0"
-  peerDependencies:
-    react: ^16.11.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/f02b3bd5a198a0f62f9a53d7c0528c4a58aa61a43310bea169614b6e873dadb52599e856ef0775405b6aa7409835343da0cf328948aa892aa309bf4b7e7d6902
-  languageName: node
-  linkType: hard
-
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -16249,13 +16096,6 @@ __metadata:
   dependencies:
     any-promise: "npm:^1.0.0"
   checksum: 10/486e1283a867440a904e36741ff1a177faa827cf94d69506f7e3ae4187b9afdf9ec368b3d8da225c192bfe2eb943f3f0080594156bf39f21b57cd1411e2e7f6d
-  languageName: node
-  linkType: hard
-
-"throttleit@npm:2.1.0":
-  version: 2.1.0
-  resolution: "throttleit@npm:2.1.0"
-  checksum: 10/a2003947aafc721c4a17e6f07db72dc88a64fa9bba0f9c659f7997d30f9590b3af22dadd6a41851e0e8497d539c33b2935c2c7919cf4255922509af6913c619b
   languageName: node
   linkType: hard
 
@@ -16988,15 +16828,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0":
-  version: 1.4.0
-  resolution: "use-sync-external-store@npm:1.4.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/08bf581a8a2effaefc355e9d18ed025d436230f4cc973db2f593166df357cf63e47b9097b6e5089b594758bde322e1737754ad64905e030d70f8ff7ee671fd01
-  languageName: node
-  linkType: hard
-
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -17602,15 +17433,6 @@ __metadata:
   version: 2.1.1
   resolution: "yoctocolors@npm:2.1.1"
   checksum: 10/563fbec88bce9716d1044bc98c96c329e1d7a7c503e6f1af68f1ff914adc3ba55ce953c871395e2efecad329f85f1632f51a99c362032940321ff80c42a6f74d
-  languageName: node
-  linkType: hard
-
-"zod-to-json-schema@npm:^3.23.5":
-  version: 3.23.5
-  resolution: "zod-to-json-schema@npm:3.23.5"
-  peerDependencies:
-    zod: ^3.23.3
-  checksum: 10/53d07a419f0f194e0b96711dc11e7e6fa52a366b0ed5fceb405dc55f13252a1bf433712e4fb496c2a5fdc851018ee1acba7b39c2265c43d6fbb180e12c110c3b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6345

### Description (What does it do?)
Removes `ai/react` package because it wasn't doing too much, and adds a AiChatWs component for websocket-based chats.

### How can this be tested?
**Option 1: Test in storybook**
1. View http://localhost:6006/?path=/docs/smoot-design-ai-aichatws--docs and http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs; interact with demos.

### Additional Context
I haven't written tests (besides storybook, I guess) for the AiChatWs component. Will do that if we settle on a WS-based API,. though I am going to recommend we stick with HTTP streaming since we don't need the 2-way communication and HTTP avoids disconnect/reconnect issues.
