### PR TITLE
fix: image aspect ratio in AiChat

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -72,6 +72,10 @@ const Avatar = styled.div(({ theme }) => ({
   justifyContent: "center",
   img: {
     width: "66%",
+    // This is the default, but NextJS adds a height attribute to images
+    // The attr is useful for aspect ratio, but we want the actual CSS size to
+    // be auto.
+    height: "auto",
   },
   width: "32px",
   height: "32px",


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #44 

### Description (What does it do?)
Fixes an image issue in NextJS

### Screenshots (if appropriate):
Regular image (storybook)
<img width="409" alt="Screenshot 2025-01-31 at 12 16 37 PM" src="https://github.com/user-attachments/assets/a2437a04-bd6a-4979-8cbc-efed5b6dc37a" />

NextJS image tag:

<img width="895" alt="Screenshot 2025-01-31 at 12 22 24 PM" src="https://github.com/user-attachments/assets/1e92482a-1faf-4132-99ed-3478d0b3a1f3" />

### How can this be tested?
We don't have a great way to test this at the moment in isolation. Smoot-design's storybook doesn't use NextJS right now (intentionally).

This can be tested on https://github.com/mitodl/mit-learn/pull/1999, which is using this branch right now.

