### PR TITLE
refactor: Migrate to MUI System styled

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     }
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
     "@mui/utils": "^6.1.6",
     "ai": "^4.0.13",
     "classnames": "^2.5.1",
@@ -73,12 +75,10 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.0.0",
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
     "@faker-js/faker": "^9.0.0",
     "@jest/environment": "^29.7.0",
-    "@mui/material": "^6.1.6",
-    "@mui/system": "^6.1.6",
+    "@mui/material": "^6.4.2",
+    "@mui/system": "^6.4.2",
     "@remixicon/react": "^4.2.0",
     "@storybook/addon-actions": "^8.4.7",
     "@storybook/addon-essentials": "^8.4.7",
@@ -99,6 +99,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.13",
+    "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/typescript-estree": "^8.13.0",
@@ -134,10 +135,6 @@
     "vite": "^6.0.7"
   },
   "peerDependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
-    "@mui/material": "^6.1.6",
-    "@mui/system": "^6.1.6",
     "@remixicon/react": "^4.2.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/material": "^6.4.2",
+    "@mui/system": "^6.4.2",
     "@mui/utils": "^6.1.6",
     "ai": "^4.0.13",
     "classnames": "^2.5.1",
@@ -77,8 +79,6 @@
     "@chromatic-com/storybook": "^3.0.0",
     "@faker-js/faker": "^9.0.0",
     "@jest/environment": "^29.7.0",
-    "@mui/material": "^6.4.2",
-    "@mui/system": "^6.4.2",
     "@remixicon/react": "^4.2.0",
     "@storybook/addon-actions": "^8.4.7",
     "@storybook/addon-essentials": "^8.4.7",

--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { AiChat } from "./AiChat"
 import type { AiChatProps } from "./types"
 import { mockJson, mockStreaming } from "./story-utils"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 import { fn } from "@storybook/test"
 
 const TEST_API_STREAMING = "http://localhost:4567/streaming"
@@ -22,7 +22,7 @@ const STARTERS = [
   { content: "I am curious about AI applications for business" },
 ]
 
-const Container = styled.div({
+const Container = styled("div")({
   width: "100%",
   height: "500px",
 })

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 import Skeleton from "@mui/material/Skeleton"
 import { Input } from "../Input/Input"
 import { ActionButton } from "../Button/ActionButton"
@@ -29,7 +29,7 @@ const classes = {
   input: "MitAiChat--input",
 }
 
-const ChatContainer = styled.div({
+const ChatContainer = styled("div")({
   width: "100%",
   height: "100%",
   display: "flex",
@@ -49,7 +49,7 @@ const MessagesContainer = styled(ScrollSnap)(({ theme }) => ({
   borderStyle: "solid",
   borderWidth: "0 1px",
 }))
-const MessageRow = styled.div<{
+const MessageRow = styled("div")<{
   reverse?: boolean
 }>({
   display: "flex",
@@ -63,7 +63,7 @@ const MessageRow = styled.div<{
   },
   position: "relative",
 })
-const Avatar = styled.div(({ theme }) => ({
+const Avatar = styled("div")(({ theme }) => ({
   flexShrink: 0,
   borderRadius: "50%",
   backgroundColor: theme.custom.colors.white,
@@ -88,7 +88,7 @@ const Avatar = styled.div(({ theme }) => ({
     right: "16px",
   },
 }))
-const Message = styled.div(({ theme }) => ({
+const Message = styled("div")(({ theme }) => ({
   border: `1px solid ${theme.custom.colors.silverGrayLight}`,
   backgroundColor: theme.custom.colors.white,
   padding: "12px",
@@ -116,14 +116,14 @@ const Message = styled.div(({ theme }) => ({
   },
 }))
 
-const StarterContainer = styled.div({
+const StarterContainer = styled("div")({
   alignSelf: "flex-end",
   alignItems: "end",
   display: "flex",
   flexDirection: "column",
   gap: "12px",
 })
-const Starter = styled.button(({ theme }) => ({
+const Starter = styled("button")(({ theme }) => ({
   border: `1px solid ${theme.custom.colors.silverGrayLight}`,
   backgroundColor: theme.custom.colors.white,
   padding: "8px 16px",
@@ -148,7 +148,7 @@ const ActionButtonStyled = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
-const DotsContainer = styled.span(({ theme }) => ({
+const DotsContainer = styled("span")(({ theme }) => ({
   display: "inline-flex",
   gap: "4px",
   ".MuiSkeleton-root": {

--- a/src/components/Button/ActionButton.tsx
+++ b/src/components/Button/ActionButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 import { pxToRem } from "../ThemeProvider/typography"
 import {
   ButtonRoot,
@@ -13,33 +13,32 @@ import type { LinkAdapterPropsOverrides } from "../LinkAdapter/LinkAdapter"
 type ActionButtonStyleProps = Omit<ButtonStyleProps, "startIcon" | "endIcon">
 type ActionButtonProps = ActionButtonStyleProps & React.ComponentProps<"button">
 
-const actionStyles = (size: ButtonSize) => {
-  return {
-    minWidth: "auto",
-    padding: 0,
-    height: {
-      small: "32px",
-      medium: "40px",
-      large: "48px",
-    }[size],
-    width: {
-      small: "32px",
-      medium: "40px",
-      large: "48px",
-    }[size],
-    "& svg, & .MuiSvgIcon-root": {
-      width: "1em",
-      height: "1em",
-      fontSize: pxToRem(
-        {
-          small: 20,
-          medium: 24,
-          large: 32,
-        }[size],
-      ),
-    },
-  }
-}
+const actionStyles = (size: ButtonSize) => ({
+  minWidth: "auto",
+  padding: 0,
+  height: {
+    small: "32px",
+    medium: "40px",
+    large: "48px",
+  }[size],
+  width: {
+    small: "32px",
+    medium: "40px",
+    large: "48px",
+  }[size],
+  "& svg, & .MuiSvgIcon-root": {
+    width: "1em",
+    height: "1em",
+    fontSize: pxToRem(
+      {
+        small: 20,
+        medium: 24,
+        large: 32,
+      }[size],
+    ),
+  },
+})
+
 /**
  * A button that should contain a remixicon icon and nothing else.
  * See [ActionButton docs](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-actionbutton--docs).
@@ -58,7 +57,9 @@ const ActionButton = styled(
   return [
     actionStyles(size),
     responsive && {
-      [theme.breakpoints.down("sm")]: actionStyles(RESPONSIVE_SIZES[size]),
+      [theme.breakpoints.down("sm")]: actionStyles(
+        RESPONSIVE_SIZES[size as ButtonSize],
+      ),
     },
   ]
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -67,6 +67,7 @@ const RESPONSIVE_SIZES: Record<ButtonSize, ButtonSize> = {
   large: "medium",
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
   color: theme.custom.colors.darkGray2,
   textAlign: "center",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
-import styled from "@emotion/styled"
-import { css } from "@emotion/react"
+import { styled } from "@mui/system"
+// import styled from "@emotion/styled"
+import { css, CSSObject } from "@emotion/react"
 import { pxToRem } from "../ThemeProvider/typography"
 import type { Theme, ThemeOptions } from "@mui/material/styles"
 import {
@@ -68,194 +69,290 @@ const RESPONSIVE_SIZES: Record<ButtonSize, ButtonSize> = {
   large: "medium",
 }
 
-const sizeStyles = (
-  size: ButtonSize,
-  hasBorder: boolean,
-  theme: Theme,
-): Partial<ThemeOptions["typography"]>[] => {
-  const paddingAdjust = hasBorder ? BORDER_WIDTHS[size] : 0
-  return [
-    {
-      boxSizing: "border-box",
-      borderWidth: BORDER_WIDTHS[size],
-    },
-    size === "large" && {
-      padding: `${14 - paddingAdjust}px 24px`,
-      ...theme.typography.buttonLarge,
-    },
-    size === "medium" && {
-      padding: `${11 - paddingAdjust}px 16px`,
-      ...theme.typography.button,
-    },
-    size === "small" && {
-      padding: `${8 - paddingAdjust}px 12px`,
-      ...theme.typography.buttonSmall,
-    },
-  ]
-}
+const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
+  color: theme.custom.colors.darkGray2,
+  textAlign: "center",
+  // display
+  display: "inline-flex",
+  justifyContent: "center",
+  alignItems: "center",
+  // transitions
+  transition: `background ${theme.transitions.duration.short}ms`,
+  // cursor
+  cursor: "pointer",
+  ":disabled": {
+    cursor: "default",
+  },
+  minWidth: "100px",
 
-const buttonStyles = (props: ButtonStyleProps & { theme: Theme }) => {
-  const { size, variant, edge, theme, color, responsive } = {
-    ...DEFAULT_PROPS,
-    ...props,
-  }
-  const { colors } = theme.custom
-  const hasBorder = variant === "secondary" || variant === "bordered"
-  return css([
+  boxSizing: "border-box",
+  borderWidth: BORDER_WIDTHS["medium"],
+  padding: "11px 16px",
+  ...theme.typography.button,
+
+  variants: [
     {
-      color: theme.palette.text.primary,
-      textAlign: "center",
-      // display
-      display: "inline-flex",
-      justifyContent: "center",
-      alignItems: "center",
-      // transitions
-      transition: `background ${theme.transitions.duration.short}ms`,
-      // cursor
-      cursor: "pointer",
-      ":disabled": {
-        cursor: "default",
-      },
-      minWidth: "100px",
+      props: { size: "large" },
+      style: theme.typography.buttonLarge,
     },
-    ...sizeStyles(size, hasBorder, theme),
-    // responsive
-    responsive && {
-      [theme.breakpoints.down("sm")]: sizeStyles(
-        RESPONSIVE_SIZES[size],
-        hasBorder,
-        theme,
-      ),
-    },
-    // variant
-    variant === "primary" && {
-      backgroundColor: colors.mitRed,
-      color: colors.white,
-      border: "none",
-      /* Shadow/04dp */
-      boxShadow:
-        "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 3px 8px 0px rgba(37, 38, 43, 0.12)",
-      ":hover:not(:disabled)": {
-        backgroundColor: colors.red,
-        boxShadow: "none",
-      },
-      ":disabled": {
-        backgroundColor: colors.silverGray,
-        boxShadow: "none",
+    {
+      props: { size: "large" },
+      style: {
+        padding: "14px 24px",
       },
     },
-    variant === "secondary" && {
-      color: colors.red,
-      backgroundColor: "transparent",
-      borderColor: "currentcolor",
-      borderStyle: "solid",
-      ":hover:not(:disabled)": {
-        // brightRed at 0.06 alpha
-        backgroundColor: "rgba(255, 20, 35, 0.06)",
-      },
-      ":disabled": {
-        color: colors.silverGray,
+    {
+      props: { size: "large", hasBorder: true },
+      style: {
+        padding: `${14 - BORDER_WIDTHS["large"]}px 24px`,
       },
     },
-    variant === "text" && {
-      backgroundColor: "transparent",
-      borderStyle: "none",
-      color: colors.darkGray2,
-      ":hover:not(:disabled)": {
-        // darkGray1 at 6% alpha
-        backgroundColor: "rgba(64, 70, 76, 0.06)",
-      },
-      ":disabled": {
-        color: colors.silverGray,
+    {
+      props: ({ size, hasBorder }: { size: ButtonSize; hasBorder: boolean }) =>
+        (!size || size === "medium") && hasBorder,
+      style: {
+        padding: `${11 - BORDER_WIDTHS["medium"]}px 16px`,
       },
     },
-    variant === "bordered" && {
-      backgroundColor: colors.white,
-      color: colors.silverGrayDark,
-      border: `1px solid ${colors.silverGrayLight}`,
-      ":hover:not(:disabled)": {
-        backgroundColor: colors.lightGray1,
-        color: colors.darkGray2,
-      },
-      ":disabled": {
-        backgroundColor: colors.lightGray2,
-        border: `1px solid ${colors.lightGray2}`,
-        color: colors.silverGrayDark,
+    {
+      props: { size: "small" },
+      style: {
+        padding: "8px 12px",
       },
     },
-    variant === "tertiary" && {
-      color: colors.darkGray2,
-      border: "none",
-      backgroundColor: colors.lightGray2,
-      ":hover:not(:disabled)": {
-        backgroundColor: colors.white,
-      },
-      ":disabled": {
-        backgroundColor: colors.lightGray2,
-        color: colors.silverGrayLight,
+    {
+      props: { size: "small", hasBorder: true },
+      style: {
+        padding: `${8 - BORDER_WIDTHS["small"]}px 12px`,
       },
     },
-    // edge
-    edge === "rounded" && {
-      borderRadius: "4px",
+    // {
+    //   props: { size: "medium" },
+    //   style: theme.typography.button,
+    // },
+    {
+      props: { size: "small" },
+      style: theme.typography.buttonSmall,
     },
-    edge === "circular" && {
-      // Pill-shaped buttons... Overlapping border radius get clipped to pill.
-      borderRadius: "100vh",
-    },
-    // color
-    color === "secondary" && {
-      color: theme.custom.colors.silverGray,
-      borderColor: theme.custom.colors.silverGray,
-      ":hover:not(:disabled)": {
-        backgroundColor: theme.custom.colors.lightGray1,
+    {
+      props: { responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: theme.typography.button,
       },
     },
-  ])
-}
+    {
+      props: { size: "large", responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: theme.typography.buttonLarge,
+      },
+    },
+    {
+      props: { size: "small", responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: theme.typography.buttonSmall,
+      },
+    },
+    {
+      props: { variant: "primary" },
+      style: {
+        backgroundColor: theme.custom.colors.mitRed,
+        color: theme.custom.colors.white,
+        border: "none",
+        /* Shadow/04dp */
+        boxShadow:
+          "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 3px 8px 0px rgba(37, 38, 43, 0.12)",
+        ":hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.red,
+          boxShadow: "none",
+        },
+        ":disabled": {
+          backgroundColor: theme.custom.colors.silverGray,
+          boxShadow: "none",
+        },
+      },
+    },
+    {
+      props: { variant: "success" },
+      style: {
+        backgroundColor: theme.custom.colors.darkGreen,
+        color: theme.custom.colors.white,
+        border: "none",
+        /* Shadow/04dp */
+        boxShadow:
+          "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 3px 8px 0px rgba(37, 38, 43, 0.12)",
+        ":hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.darkGreen,
+          boxShadow: "none",
+        },
+        ":disabled": {
+          backgroundColor: theme.custom.colors.silverGray,
+          boxShadow: "none",
+        },
+      },
+    },
+    {
+      props: { variant: "secondary" },
+      style: {
+        color: theme.custom.colors.red,
+        backgroundColor: "transparent",
+        borderColor: "currentcolor",
+        borderStyle: "solid",
+        ":hover:not(:disabled)": {
+          // TODO
+          // backgroundColor: tinycolor(theme.custom.colors.brightRed)
+          //   .setAlpha(0.06)
+          //   .toString(),
+        },
+        ":disabled": {
+          color: theme.custom.colors.silverGray,
+        },
+      },
+    },
+    {
+      props: { variant: "text" },
+      style: {
+        backgroundColor: "transparent",
+        borderStyle: "none",
+        color: theme.custom.colors.darkGray2,
+        ":hover:not(:disabled)": {
+          // TODO
+          // backgroundColor: tinycolor(theme.custom.colors.darkGray1)
+          //   .setAlpha(0.06)
+          //   .toString(),
+        },
+        ":disabled": {
+          color: theme.custom.colors.silverGray,
+        },
+      },
+    },
+    {
+      props: { variant: "bordered" },
+      style: {
+        backgroundColor: theme.custom.colors.white,
+        color: theme.custom.colors.silverGrayDark,
+        border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+        ":hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.lightGray1,
+          color: theme.custom.colors.darkGray2,
+        },
+        ":disabled": {
+          backgroundColor: theme.custom.colors.lightGray2,
+          border: `1px solid ${theme.custom.colors.lightGray2}`,
+          color: theme.custom.colors.silverGrayDark,
+        },
+      },
+    },
+    {
+      props: { variant: "noBorder" },
+      style: {
+        backgroundColor: theme.custom.colors.white,
+        color: theme.custom.colors.darkGray2,
+        border: "none",
+        ":hover:not(:disabled)": {
+          // TODO
+          // backgroundColor: tinycolor(theme.custom.colors.darkGray1)
+          //   .setAlpha(0.06)
+          //   .toString(),
+        },
+        ":disabled": {
+          color: theme.custom.colors.silverGray,
+        },
+      },
+    },
+    {
+      props: { variant: "tertiary" },
+      style: {
+        color: theme.custom.colors.darkGray2,
+        border: "none",
+        backgroundColor: theme.custom.colors.lightGray2,
+        ":hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.white,
+        },
+        ":disabled": {
+          backgroundColor: theme.custom.colors.lightGray2,
+          color: theme.custom.colors.silverGrayLight,
+        },
+      },
+    },
+    {
+      props: { variant: "inverted" },
+      style: {
+        backgroundColor: theme.custom.colors.white,
+        color: theme.custom.colors.mitRed,
+        borderColor: theme.custom.colors.mitRed,
+        borderStyle: "solid",
+      },
+    },
+    {
+      props: { edge: "rounded" },
+      style: {
+        borderRadius: "4px",
+      },
+    },
+    {
+      props: { edge: "circular" },
+      style: {
+        // Pill-shaped buttons... Overlapping border radius get clipped to pill.
+        borderRadius: "100vh",
+      },
+    },
+    {
+      props: { color: "secondary" },
+      style: {
+        color: theme.custom.colors.silverGray,
+        borderColor: theme.custom.colors.silverGray,
+        ":hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.lightGray1,
+        },
+      },
+    },
+  ],
+})
 
 const ButtonRoot = styled("button", {
   shouldForwardProp: shouldForwardButtonProp,
 })<ButtonStyleProps>(buttonStyles)
+
 const ButtonLinkRoot = styled(LinkAdapter, {
   shouldForwardProp: shouldForwardButtonProp,
 })<ButtonStyleProps>(buttonStyles)
 
-const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
-  ({ size, side }) => [
-    {
+const IconContainer = styled("span")<{
+  side: "start" | "end"
+  size: ButtonSize
+}>(({ size, side }) => [
+  {
+    height: "1em",
+    display: "flex",
+    alignItems: "center",
+  },
+  side === "start" && {
+    /**
+     * The negative margin is to counteract the padding on the button itself.
+     * Without icons, the left space is 24/16/12 px.
+     * With icons, the left space is 20/12/8 px.
+     */
+    marginLeft: "-4px",
+    marginRight: "8px",
+  },
+  side === "end" && {
+    marginLeft: "8px",
+    marginRight: "-4px",
+  },
+  {
+    "& svg, & .MuiSvgIcon-root": {
+      width: "1em",
       height: "1em",
-      display: "flex",
-      alignItems: "center",
+      fontSize: pxToRem(
+        {
+          small: 16,
+          medium: 20,
+          large: 24,
+        }[size],
+      ),
     },
-    side === "start" && {
-      /**
-       * The negative margin is to counteract the padding on the button itself.
-       * Without icons, the left space is 24/16/12 px.
-       * With icons, the left space is 20/12/8 px.
-       */
-      marginLeft: "-4px",
-      marginRight: "8px",
-    },
-    side === "end" && {
-      marginLeft: "8px",
-      marginRight: "-4px",
-    },
-    {
-      "& svg, & .MuiSvgIcon-root": {
-        width: "1em",
-        height: "1em",
-        fontSize: pxToRem(
-          {
-            small: 16,
-            medium: 20,
-            large: 24,
-          }[size],
-        ),
-      },
-    },
-  ],
-)
+  },
+])
 
 const ButtonInner: React.FC<
   ButtonStyleProps & { children?: React.ReactNode }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,7 @@
 import * as React from "react"
-import { styled } from "@mui/system"
-// import styled from "@emotion/styled"
-import { css, CSSObject } from "@emotion/react"
+import { styled } from "@mui/material/styles"
 import { pxToRem } from "../ThemeProvider/typography"
-import type { Theme, ThemeOptions } from "@mui/material/styles"
+import type { Theme } from "@mui/material/styles"
 import {
   LinkAdapter,
   LinkAdapterPropsOverrides,
@@ -84,20 +82,17 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
     cursor: "default",
   },
   minWidth: "100px",
-
   boxSizing: "border-box",
   borderWidth: BORDER_WIDTHS["medium"],
   padding: "11px 16px",
+  borderRadius: "4px",
   ...theme.typography.button,
 
   variants: [
     {
       props: { size: "large" },
-      style: theme.typography.buttonLarge,
-    },
-    {
-      props: { size: "large" },
       style: {
+        ...theme.typography.buttonLarge,
         padding: "14px 24px",
       },
     },
@@ -117,6 +112,7 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
     {
       props: { size: "small" },
       style: {
+        ...theme.typography.buttonSmall,
         padding: "8px 12px",
       },
     },
@@ -125,14 +121,6 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
       style: {
         padding: `${8 - BORDER_WIDTHS["small"]}px 12px`,
       },
-    },
-    // {
-    //   props: { size: "medium" },
-    //   style: theme.typography.button,
-    // },
-    {
-      props: { size: "small" },
-      style: theme.typography.buttonSmall,
     },
     {
       props: { responsive: true },
@@ -281,12 +269,6 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
         color: theme.custom.colors.mitRed,
         borderColor: theme.custom.colors.mitRed,
         borderStyle: "solid",
-      },
-    },
-    {
-      props: { edge: "rounded" },
-      style: {
-        borderRadius: "4px",
       },
     },
     {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -84,7 +84,7 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
   minWidth: "100px",
   boxSizing: "border-box",
   borderWidth: BORDER_WIDTHS["medium"],
-  padding: "11px 16px",
+  padding: "10px 16px",
   borderRadius: "4px",
   ...theme.typography.button,
 
@@ -276,6 +276,12 @@ const buttonStyles: any = ({ theme }: { theme: Theme }) => ({
       style: {
         // Pill-shaped buttons... Overlapping border radius get clipped to pill.
         borderRadius: "100vh",
+      },
+    },
+    {
+      props: { edge: "none" },
+      style: {
+        borderRadius: 0,
       },
     },
     {

--- a/src/components/ImageAdapter/ImageAdapter.tsx
+++ b/src/components/ImageAdapter/ImageAdapter.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useTheme } from "@emotion/react"
+import { useTheme } from "@mui/material/styles"
 
 /**
  * ImageAdapterPropsOverrides can be used with module augmentation to provide

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -49,6 +49,16 @@ const meta: Meta<typeof Input> = {
   title: "smoot-design/Input",
   component: Input,
   argTypes: {
+    size: {
+      options: SIZES,
+      mapping: SIZES,
+      control: { type: "radio" },
+    },
+    responsive: {
+      options: [true, false],
+      mapping: [true, false],
+      control: { type: "boolean" },
+    },
     startAdornment: {
       options: Object.keys(ADORNMENTS),
       mapping: ADORNMENTS,
@@ -64,6 +74,7 @@ const meta: Meta<typeof Input> = {
     onChange: fn(),
     value: "some value",
     placeholder: "placeholder",
+    size: "medium",
   },
 }
 export default meta

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
-import styled from "@emotion/styled"
-import { css } from "@emotion/react"
+import { styled } from "@mui/material/styles"
 import InputBase from "@mui/material/InputBase"
 import type { InputBaseProps } from "@mui/material/InputBase"
 import type { Theme } from "@mui/material/styles"
@@ -33,11 +32,6 @@ type InputProps = CustomInputProps &
   MuiDocOverride &
   Omit<InputBaseProps, "color" | keyof MuiDocOverride>
 
-const defaultProps = {
-  size: "medium",
-  multiline: false,
-} as const
-
 const responsiveSize: Record<Size, Size> = {
   small: "small",
   medium: "small",
@@ -46,17 +40,18 @@ const responsiveSize: Record<Size, Size> = {
 }
 
 type SizeStyleProps = {
-  size: Size
   theme: Theme
+  size: Size
   multiline?: boolean
 }
-const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
-  css([
+const sizeStyles = ({ theme, size, multiline }: SizeStyleProps) => {
+  return Object.assign(
+    {},
     (size === "small" || size === "medium") && {
       ...theme.typography.body2,
     },
     (size === "large" || size === "hero") && {
-      ".remixicon": {
+      "&& .remixicon": {
         width: "24px",
         height: "24px",
       },
@@ -114,7 +109,8 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
         width: "72px",
       },
     },
-  ])
+  )
+}
 
 /**
  * Base styles for Input and Select components. Includes border, color, hover effects.
@@ -188,21 +184,121 @@ const noForward = Object.keys({
  * - [Smoot Design Input Documentation](https://mitodl.github.io/smoot-design/https://mitodl.github.io/smoot-design/)
  * - [InputBase Documentation](https://mui.com/api/input-base/)
  */
-const Input: React.FC<InputProps> = styled(InputBase, {
-  shouldForwardProp: (prop) => !noForward.includes(prop),
-})<InputProps>(({ theme, size = defaultProps.size, multiline, responsive }) => [
-  baseInputStyles(theme),
-  sizeStyles({ size, theme, multiline }),
-  responsive && {
-    [theme.breakpoints.down("sm")]: sizeStyles({
-      size: responsiveSize[size],
-      theme,
-      multiline,
-    }),
-  },
-])
+const Input = styled(InputBase, {
+  shouldForwardProp: (prop: string) => !noForward.includes(prop),
+})<InputProps>(({ theme }) => ({
+  ...baseInputStyles(theme),
+  ...sizeStyles({ theme, size: "medium" }),
+  variants: [
+    {
+      props: { size: "small" },
+      style: sizeStyles({ theme, size: "small" }),
+    },
+    {
+      props: { size: "large" },
+      style: sizeStyles({ theme, size: "large" }),
+    },
+    {
+      props: { size: "hero" },
+      style: sizeStyles({ theme, size: "hero" }),
+    },
+    {
+      props: { size: "small", multiline: true },
+      style: sizeStyles({ theme, size: "small", multiline: true }),
+    },
+    {
+      props: { size: "medium", multiline: true },
+      style: sizeStyles({ theme, size: "medium", multiline: true }),
+    },
+    {
+      props: { size: "large", multiline: true },
+      style: sizeStyles({ theme, size: "large", multiline: true }),
+    },
+    {
+      props: { size: "hero", multiline: true },
+      style: sizeStyles({ theme, size: "hero", multiline: true }),
+    },
+    {
+      props: { size: "small", responsive: true },
+      style: {
+        // TODO breakpoints in here are not working
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["small"],
+        }),
+      },
+    },
+    {
+      props: { size: "medium", responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["medium"],
+        }),
+      },
+    },
+    {
+      props: { size: "large", responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["large"],
+        }),
+      },
+    },
+    {
+      props: { size: "hero", responsive: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["hero"],
+        }),
+      },
+    },
+    {
+      props: { size: "small", responsive: true, multiline: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["small"],
+          multiline: true,
+        }),
+      },
+    },
+    {
+      props: { size: "medium", responsive: true, multiline: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["medium"],
+          multiline: true,
+        }),
+      },
+    },
+    {
+      props: { size: "large", responsive: true, multiline: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["large"],
+          multiline: true,
+        }),
+      },
+    },
+    {
+      props: { size: "hero", responsive: true, multiline: true },
+      style: {
+        [theme.breakpoints.down("sm")]: sizeStyles({
+          theme,
+          size: responsiveSize["hero"],
+          multiline: true,
+        }),
+      },
+    },
+  ],
+}))
 
-const AdornmentButtonStyled = styled.button(({ theme }) => ({
+const AdornmentButtonStyled = styled("button")(({ theme }) => ({
   // font
   ...theme.typography.button,
   // display

--- a/src/components/LinkAdapter/LinkAdapter.tsx
+++ b/src/components/LinkAdapter/LinkAdapter.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import { useTheme } from "@emotion/react"
-import styled from "@emotion/styled"
+import { useTheme } from "@mui/material/styles"
+import { styled } from "@mui/material/styles"
 
-const PlainLink = styled.a({
+const PlainLink = styled("a")({
   color: "inherit",
   textDecoration: "none",
 })

--- a/src/components/LinkAdapter/LinkAdapter.tsx
+++ b/src/components/LinkAdapter/LinkAdapter.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
-import { useTheme } from "@mui/material/styles"
-import { styled } from "@mui/material/styles"
+import { styled, useTheme } from "@mui/material/styles"
 
 const PlainLink = styled("a")({
   color: "inherit",

--- a/src/components/ScrollSnap/ScrollSnap.stories.tsx
+++ b/src/components/ScrollSnap/ScrollSnap.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { ScrollSnap } from "./ScrollSnap"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 import { faker } from "@faker-js/faker/locale/en"
 import { useInterval } from "../../utils/useInterval"
 import Slider from "@mui/material/Slider"

--- a/src/components/ScrollSnap/ScrollSnap.tsx
+++ b/src/components/ScrollSnap/ScrollSnap.tsx
@@ -1,6 +1,6 @@
-import { composeRefs } from "../../utils/composeRefs"
-import styled from "@emotion/styled"
 import * as React from "react"
+import { composeRefs } from "../../utils/composeRefs"
+import { styled } from "@mui/material/styles"
 
 /**
  * Returns the distance between visible content and the bottom of the element.
@@ -16,7 +16,7 @@ const scrollToBottom = (el: HTMLElement) => {
   el.scrollTop = el.scrollHeight
 }
 
-const Scroller = styled.div({
+const Scroller = styled("div")({
   overflow: "auto",
 })
 
@@ -38,7 +38,7 @@ type ScrollSnapProps = {
  */
 const ScrollSnap = React.forwardRef<HTMLDivElement, ScrollSnapProps>(
   function ScrollSnap({ children, threshold = 2, className }, ref) {
-    const el = React.useRef<HTMLDivElement>()
+    const el = React.useRef<HTMLDivElement>(null)
 
     // `content` a delayed version of children to allow measuring scroll position
     // using the old children.

--- a/src/components/SrAnnouncer/SrAnnouncer.stories.tsx
+++ b/src/components/SrAnnouncer/SrAnnouncer.stories.tsx
@@ -1,21 +1,23 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { SrAnnouncer } from "./SrAnnouncer"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 
-const Container = styled.div<{ forceVisible?: boolean }>(({ forceVisible }) => [
-  forceVisible && {
-    width: "100% !important",
-    height: "100px !important",
-    "& > *:first-of-type": {
-      width: "unset !important",
-      height: "unset !important",
-      clipPath: "none !important",
-      clip: "unset !important",
-      position: "unset !important" as "unset",
+const Container = styled("div")<{ forceVisible?: boolean }>(
+  ({ forceVisible }) => [
+    forceVisible && {
+      width: "100% !important",
+      height: "100px !important",
+      "& > *:first-of-type": {
+        width: "unset !important",
+        height: "unset !important",
+        clipPath: "none !important",
+        clip: "unset !important",
+        position: "unset !important" as "unset",
+      },
     },
-  },
-])
+  ],
+)
 
 const meta: Meta<typeof SrAnnouncer> = {
   title: "smoot-design/ScreenreaderAnnouncer",

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -13,6 +13,7 @@ type TextFieldProps = Omit<FormFieldWrapperProps, "children"> & {
   onChange?: React.ChangeEventHandler<HTMLInputElement>
   onBlur?: React.FocusEventHandler<HTMLInputElement>
   fullWidth?: boolean
+
   /**
    * Props forwarded to root of `<Input />`
    */

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,4 @@
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 
 /**
  * VisuallyHidden is a utility component that hides its children from sighted
@@ -19,7 +19,7 @@ import styled from "@emotion/styled"
  *
  * The CSS here is based on https://inclusive-components.design/tooltips-toggletips/
  */
-const VisuallyHidden = styled.span({
+const VisuallyHidden = styled("span")({
   clipPath: "inset(100%)",
   clip: "rect(1px, 1px, 1px, 1px)",
   height: "1px",

--- a/src/components/internal/FormHelpers/FormHelpers.tsx
+++ b/src/components/internal/FormHelpers/FormHelpers.tsx
@@ -1,48 +1,53 @@
 import * as React from "react"
-import styled from "@emotion/styled"
+import { styled } from "@mui/material/styles"
 import { RiErrorWarningLine } from "@remixicon/react"
 import Typography from "@mui/material/Typography"
 
-const Required = styled.span(({ theme }) => ({
+const Required = styled("span")(({ theme }) => ({
   color: theme.custom.colors.lightRed,
   marginLeft: "4px",
 }))
 
-const Description = styled.div<{ error?: boolean }>(({ theme, error }) => [
-  {
-    ...theme.typography.body2,
-    color: error
-      ? theme.custom.colors.lightRed
-      : theme.custom.colors.silverGrayDark,
-  },
-  error && {
-    textIndent: "-24px",
-    paddingLeft: "24px",
+const Description = styled("div")<{ error?: boolean }>(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  variants: [
+    {
+      props: { error: true },
+      style: {
+        color: theme.custom.colors.lightRed,
+        textIndent: "-24px",
+        paddingLeft: "24px",
 
-    "> svg:first-of-type": {
-      marginRight: "4px",
-      transform: "translateY(2px)",
-      width: "18px",
-      height: "18px",
-      position: "relative",
-      top: "2px",
+        "> svg:first-of-type": {
+          marginRight: "4px",
+          transform: "translateY(2px)",
+          width: "18px",
+          height: "18px",
+          position: "relative",
+          top: "2px",
+        },
+      },
     },
-  },
-])
+  ],
+}))
 
-const Container = styled.div<{ fullWidth?: boolean }>(({ fullWidth }) => [
-  {
-    display: "inline-flex",
-    flexDirection: "column",
-    alignItems: "start",
-    "> *:not(:last-child)": {
-      marginBottom: "4px",
+const Container = styled("div")<{ fullWidth?: boolean }>({
+  display: "inline-flex",
+  flexDirection: "column",
+  alignItems: "start",
+  "> *:not(:last-child)": {
+    marginBottom: "4px",
+  },
+  variants: [
+    {
+      props: { fullWidth: true },
+      style: {
+        width: "100%",
+      },
     },
-  },
-  fullWidth && {
-    width: "100%",
-  },
-])
+  ],
+})
 
 type ControlLabelProps = {
   htmlFor: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 "use client"
 
-export { default as styled } from "@emotion/styled"
-export { css, Global } from "@emotion/react"
-
 export {
   ThemeProvider,
   createTheme,

--- a/src/type-augmentation/TypescriptDocs.mdx
+++ b/src/type-augmentation/TypescriptDocs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/blocks"
 
 # Type Augmentation
 
-Smoot Design uses Typescript's module augmentation to enhance types provided by `@emotion` and `@mui` packages. For example, we add custom theme properties (`theme.custom`) to the default theme and add new properties / values to some MUI components.
+Smoot Design uses Typescript's module augmentation to enhance types provided and `@mui` packages. For example, we add custom theme properties (`theme.custom`) to the default theme and add new properties / values to some MUI components.
 
 To enable this module augmentation in a consuming application or library, either:
 
@@ -13,5 +13,5 @@ To enable this module augmentation in a consuming application or library, either
 
 For more information on this subject, see:
 
-- TS Documenation: [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
+- TS Documentation: [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
 - MUI Documentation: [Theming/Typescript](https://mui.com/material-ui/customization/theming/#typescript)

--- a/src/type-augmentation/theme.d.ts
+++ b/src/type-augmentation/theme.d.ts
@@ -1,6 +1,4 @@
 import type { Theme as MuiTheme } from "@mui/material/styles"
-import "@emotion/react"
-import "@emotion/styled"
 
 export interface ColorGroup {
   main: string
@@ -97,8 +95,14 @@ declare module "@mui/material/Chip" {
   }
 }
 
-declare module "@emotion/react" {
-  export interface Theme extends MuiTheme {
-    custom: CustomTheme
+declare module "@mui/system" {
+  export interface styled {
+    theme: CustomTheme
   }
 }
+// import { Theme } from "@mui/material"
+// declare module "@mui/material/styles" {
+//   interface Typography {
+//     button: React.CSSProperties
+//   }
+// }

--- a/src/type-augmentation/theme.d.ts
+++ b/src/type-augmentation/theme.d.ts
@@ -1,5 +1,3 @@
-import type { Theme as MuiTheme } from "@mui/material/styles"
-
 export interface ColorGroup {
   main: string
   highlight: string
@@ -100,9 +98,3 @@ declare module "@mui/system" {
     theme: CustomTheme
   }
 }
-// import { Theme } from "@mui/material"
-// declare module "@mui/material/styles" {
-//   interface Typography {
-//     button: React.CSSProperties
-//   }
-// }

--- a/src/utils/composeRefs.test.tsx
+++ b/src/utils/composeRefs.test.tsx
@@ -4,8 +4,8 @@ import { render, screen } from "@testing-library/react"
 
 describe("composeRefs", () => {
   test("Composing object + fn ref", () => {
-    const objRef1: React.RefObject<HTMLDivElement> = { current: null }
-    const objRef2: React.RefObject<HTMLDivElement> = { current: null }
+    const objRef1 = React.createRef<HTMLDivElement>()
+    const objRef2 = React.createRef<HTMLDivElement>()
     const fnRef1 = jest.fn()
     const fnRef2 = jest.fn()
 

--- a/src/utils/useInterval.ts
+++ b/src/utils/useInterval.ts
@@ -6,7 +6,7 @@ import { useRef, useEffect } from "react"
  * Based on https://overreacted.io/making-setinterval-declarative-with-react-hooks/
  */
 const useInterval = (callback: () => void, delay: number | null) => {
-  const savedCallback = useRef<() => void>()
+  const savedCallback = useRef<() => void>(() => {})
 
   useEffect(() => {
     savedCallback.current = callback

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,7 +1458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.8.4":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -1467,7 +1467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.18.3":
+"@babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.26.7
   resolution: "@babel/runtime@npm:7.26.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,12 +1458,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10/9f4ea1c1d566c497c052d505587554e782e021e6ccd302c2ad7ae8291c8e16e3f19d4a7726fb64469e057779ea2081c28b7dbefec6d813a22f08a35712c0f699
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.18.3":
+  version: 7.26.7
+  resolution: "@babel/runtime@npm:7.26.7"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10/c7a661a6836b332d9d2e047cba77ba1862c1e4f78cec7146db45808182ef7636d8a7170be9797e5d8fd513180bffb9fa16f6ca1c69341891efec56113cf22bfc
   languageName: node
   linkType: hard
 
@@ -1550,35 +1559,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.12.0":
-  version: 11.12.0
-  resolution: "@emotion/babel-plugin@npm:11.12.0"
+"@emotion/babel-plugin@npm:^11.13.5":
+  version: 11.13.5
+  resolution: "@emotion/babel-plugin@npm:11.13.5"
   dependencies:
     "@babel/helper-module-imports": "npm:^7.16.7"
     "@babel/runtime": "npm:^7.18.3"
     "@emotion/hash": "npm:^0.9.2"
     "@emotion/memoize": "npm:^0.9.0"
-    "@emotion/serialize": "npm:^1.2.0"
+    "@emotion/serialize": "npm:^1.3.3"
     babel-plugin-macros: "npm:^3.1.0"
     convert-source-map: "npm:^1.5.0"
     escape-string-regexp: "npm:^4.0.0"
     find-root: "npm:^1.1.0"
     source-map: "npm:^0.5.7"
     stylis: "npm:4.2.0"
-  checksum: 10/fe6f4522ea2b61ef4214dd0b0f3778aad9c18434b47e50ae5091af226526bf305455c313065826a090682520c9462c151d4df62ec128f14671d3125afc05b148
+  checksum: 10/cd310568314d886ca328e504f84c4f7f9c7f092ea34a2b43fdb61f84665bf301ba2ef49e0fd1e7ded3d81363d9bbefbb32674ce88b317cfb64db2b65e5ff423f
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.13.0, @emotion/cache@npm:^11.13.1":
-  version: 11.13.1
-  resolution: "@emotion/cache@npm:11.13.1"
+"@emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
     "@emotion/memoize": "npm:^0.9.0"
     "@emotion/sheet": "npm:^1.4.0"
-    "@emotion/utils": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
     "@emotion/weak-memoize": "npm:^0.4.0"
     stylis: "npm:4.2.0"
-  checksum: 10/090c8ad2e5b23f1b3a95e94f1f0554a40ed1dcd844c9d31629a68ff824eff40f32d1362f67aefa440ee0aabd5a8cabcc76870fd6d77144d3ff251bdcdf1420b9
+  checksum: 10/52336b28a27b07dde8fcdfd80851cbd1487672bbd4db1e24cca1440c95d8a6a968c57b0453c2b7c88d9b432b717f99554dbecc05b5cdef27933299827e69fd8e
   languageName: node
   linkType: hard
 
@@ -1605,16 +1614,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:^11.11.1":
-  version: 11.13.3
-  resolution: "@emotion/react@npm:11.13.3"
+"@emotion/react@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@emotion/react@npm:11.14.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
-    "@emotion/babel-plugin": "npm:^11.12.0"
-    "@emotion/cache": "npm:^11.13.0"
-    "@emotion/serialize": "npm:^1.3.1"
-    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.1.0"
-    "@emotion/utils": "npm:^1.4.0"
+    "@emotion/babel-plugin": "npm:^11.13.5"
+    "@emotion/cache": "npm:^11.14.0"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.2.0"
+    "@emotion/utils": "npm:^1.4.2"
     "@emotion/weak-memoize": "npm:^0.4.0"
     hoist-non-react-statics: "npm:^3.3.1"
   peerDependencies:
@@ -1622,20 +1631,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ee70d3afc2e8dd771e6fe176d27dd87a5e21a54e54d871438fd1caa5aa2312d848c6866292fdc65a6ea1c945147c8422bda2d22ed739178af9902dc86d6b298a
+  checksum: 10/3356c1d66f37f4e7abf88a2be843f6023b794b286c9c99a0aaf1cd1b2b7c50f8d80a2ef77183da737de70150f638e698ff4a2a38ab2d922f868615f1d5761c37
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.2.0, @emotion/serialize@npm:^1.3.0, @emotion/serialize@npm:^1.3.1, @emotion/serialize@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@emotion/serialize@npm:1.3.2"
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
   dependencies:
     "@emotion/hash": "npm:^0.9.2"
     "@emotion/memoize": "npm:^0.9.0"
     "@emotion/unitless": "npm:^0.10.0"
-    "@emotion/utils": "npm:^1.4.1"
+    "@emotion/utils": "npm:^1.4.2"
     csstype: "npm:^3.0.2"
-  checksum: 10/ead557c1ff19d917ef8169c02738ef36f0851fbfdf0bf69a543045bddea3b7281dc8252ee466cc5fb44ed27d1e61280ff943bb60a2c04158751fb07b3457cc93
+  checksum: 10/44a2e06fc52dba177d9cf720f7b2c5d45ee4c0d9c09b78302d9a625e758d728ef3ae26f849237fec6f70e9eeb7d87e45a65028e944dc1f877df97c599f1cdaee
   languageName: node
   linkType: hard
 
@@ -1646,23 +1655,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:^11.11.0":
-  version: 11.13.0
-  resolution: "@emotion/styled@npm:11.13.0"
+"@emotion/styled@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@emotion/styled@npm:11.14.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
-    "@emotion/babel-plugin": "npm:^11.12.0"
+    "@emotion/babel-plugin": "npm:^11.13.5"
     "@emotion/is-prop-valid": "npm:^1.3.0"
-    "@emotion/serialize": "npm:^1.3.0"
-    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.1.0"
-    "@emotion/utils": "npm:^1.4.0"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.2.0"
+    "@emotion/utils": "npm:^1.4.2"
   peerDependencies:
     "@emotion/react": ^11.0.0-rc.0
     react: ">=16.8.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5463a0f15fc12a9e20340f52df49461e948c3ae7e2dd763db0ff937b0b96dd4e82eed85cd15e24621efb3b097a095b88b01d60f50cf6f38fe3ab7db6e77f9615
+  checksum: 10/64bb3fd8c5d3042ba803eb2052fddf8e057b927682677f8fc41ecfe2b1abcc0da03944fde79fac8f2f55a56383d5c9547b93d4641bb51452cf59415c02dd9b10
   languageName: node
   linkType: hard
 
@@ -1673,19 +1682,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/use-insertion-effect-with-fallbacks@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.1.0"
+"@emotion/use-insertion-effect-with-fallbacks@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.2.0"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 10/33a10f44a873b3f5ccd2a1a3d13c2f34ed628f5a2be1ccf28540a86535a14d3a930afcbef209d48346a22ec60ff48f43c86ee9c846b9480d23a55a17145da66c
+  checksum: 10/2374999db8d53ef661d61ed1026c42a849632e4f03826f7eba0314c1d92ae342161d737f5045453aa46dd4008e13ccefeba68d3165b667dfad8e5784fcb0c643
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.4.0, @emotion/utils@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@emotion/utils@npm:1.4.1"
-  checksum: 10/95e56fc0c9e05cf01a96268f0486ce813f1109a8653d2f575c67df9e8765d9c1b2daf09ad1ada67d933efbb08ca7990228e14b210c713daf90156b4869abe6a7
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10/e5f3b8bca066b3361a7ad9064baeb9d01ed1bf51d98416a67359b62cb3affec6bb0249802c4ed11f4f8030f93cc4b67506909420bdb110adec6983d712897208
   languageName: node
   linkType: hard
 
@@ -2656,12 +2665,12 @@ __metadata:
   resolution: "@mitodl/smoot-design@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^3.0.0"
-    "@emotion/react": "npm:^11.11.1"
-    "@emotion/styled": "npm:^11.11.0"
+    "@emotion/react": "npm:^11.14.0"
+    "@emotion/styled": "npm:^11.14.0"
     "@faker-js/faker": "npm:^9.0.0"
     "@jest/environment": "npm:^29.7.0"
-    "@mui/material": "npm:^6.1.6"
-    "@mui/system": "npm:^6.1.6"
+    "@mui/material": "npm:^6.4.2"
+    "@mui/system": "npm:^6.4.2"
     "@mui/utils": "npm:^6.1.6"
     "@remixicon/react": "npm:^4.2.0"
     "@storybook/addon-actions": "npm:^8.4.7"
@@ -2683,6 +2692,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.17.13"
+    "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.13.0"
     "@typescript-eslint/typescript-estree": "npm:^8.13.0"
@@ -2723,43 +2733,39 @@ __metadata:
     vite: "npm:^6.0.7"
     zod: "npm:^3.23.8"
   peerDependencies:
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@mui/material": ^6.1.6
-    "@mui/system": ^6.1.6
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
 
-"@mui/core-downloads-tracker@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/core-downloads-tracker@npm:6.1.6"
-  checksum: 10/c09af6c9888756ae4bef802ef6fe9a23504731d6181790fdcb3ff41a6c936ef1fc0a1afe28320f4696bdc136ddefea4f89b230f0ee4e47e294dcdec8293d5d07
+"@mui/core-downloads-tracker@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/core-downloads-tracker@npm:6.4.2"
+  checksum: 10/37eab94ea69f9d13cc389e874f05be889a021531f72a21bce4e6475b5c472e616c48887a70b9db6b70658834adea94e5dd17ac63db4f6976ede823c379b8334a
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/material@npm:6.1.6"
+"@mui/material@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/material@npm:6.4.2"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/core-downloads-tracker": "npm:^6.1.6"
-    "@mui/system": "npm:^6.1.6"
-    "@mui/types": "npm:^7.2.19"
-    "@mui/utils": "npm:^6.1.6"
+    "@mui/core-downloads-tracker": "npm:^6.4.2"
+    "@mui/system": "npm:^6.4.2"
+    "@mui/types": "npm:^7.2.21"
+    "@mui/utils": "npm:^6.4.2"
     "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.11"
+    "@types/react-transition-group": "npm:^4.4.12"
     clsx: "npm:^2.1.1"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
+    react-is: "npm:^19.0.0"
     react-transition-group: "npm:^4.4.5"
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@mui/material-pigment-css": ^6.1.6
+    "@mui/material-pigment-css": ^6.4.2
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2772,16 +2778,16 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10/3a805c86fd3bc475ccd185904fb68e46358a67a9f72b88987d497d65ec982f78a5ebf6c6a3c5b52383b0208a25f1a6ead8955dec7b054f854c9f77701cafc7b9
+  checksum: 10/f972d823f674523aaeeb9d0e26d9a4d1ce0468f3534ae89d7eb2bed86fba37fd92b92d34b17fed0a8788745edf2defbad2b4cfe10dd24bc23273dc3ed44d776f
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/private-theming@npm:6.1.6"
+"@mui/private-theming@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/private-theming@npm:6.4.2"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/utils": "npm:^6.1.6"
+    "@mui/utils": "npm:^6.4.2"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2789,17 +2795,17 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b79c7d130925f91be863700c442936b51e27c102535e3502005328c30fad11ffa9f80240b213b2094107f9240d3836b583a6e4a98337a912b558d144fd6e29b4
+  checksum: 10/0a2c87868c597556ea44a720ff4804cd40fdbaf01adbb0a60aa9b248ea1f55765e5faa5e21a0de75bccb5f4033499ae306e1d959e55fee500db27e688f434068
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/styled-engine@npm:6.1.6"
+"@mui/styled-engine@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/styled-engine@npm:6.4.2"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@emotion/cache": "npm:^11.13.1"
-    "@emotion/serialize": "npm:^1.3.2"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
     "@emotion/sheet": "npm:^1.4.0"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
@@ -2812,19 +2818,19 @@ __metadata:
       optional: true
     "@emotion/styled":
       optional: true
-  checksum: 10/0506a3d771d117d0c422c74295cf19338b00030f98707082e7c87b48931587a194a12eb5ff899407d37cb4c130c93b936731e874be938c3883993ad28baa13c9
+  checksum: 10/2d486c42e594ee94849701378f08a0a25cff1cd1deec99d14a210b694ce59c7b949e8a45c9f04c22813512d93957645057701e674846fa1a72828c9b47c208b8
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/system@npm:6.1.6"
+"@mui/system@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/system@npm:6.4.2"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/private-theming": "npm:^6.1.6"
-    "@mui/styled-engine": "npm:^6.1.6"
-    "@mui/types": "npm:^7.2.19"
-    "@mui/utils": "npm:^6.1.6"
+    "@mui/private-theming": "npm:^6.4.2"
+    "@mui/styled-engine": "npm:^6.4.2"
+    "@mui/types": "npm:^7.2.21"
+    "@mui/utils": "npm:^6.4.2"
     clsx: "npm:^2.1.1"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
@@ -2840,7 +2846,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10/00e55bcff7228fa668fe517f74deeb22fa57155f3c181617519e729b36fc7ffb9d1aac7450c33f36456d78fdd369e5ffda6747d459569848915fd69c0b39a8d9
+  checksum: 10/62568345ab608d470c6ce71741dc7c40e55328656cd4459dfb244a9f37a0d1c5bba238d7b5eeee953e7b3d0e4241019b1df4217502a27c841ed16b0bc889221e
   languageName: node
   linkType: hard
 
@@ -2853,6 +2859,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/a23bc280c0722527ce5e264b0dcb44271441e4016eb2285acc1f0d236cf78c73ecc3ec7abba81876c2eadf45b905b55eb26e0e824ea6afc233efce2ef5a34f7d
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.2.21":
+  version: 7.2.22
+  resolution: "@mui/types@npm:7.2.22"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/fca63bf0b082366c8bb70d5798ae348363f7f88b7523d91bcb49dfdf9c147edfc2795b58b849caec6874a445347778572e6d7cdee22151e6e325161dfb23ab20
   languageName: node
   linkType: hard
 
@@ -2873,6 +2891,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/0af3d8b03ccfce126f05e1ffa8a01ab993a6e9c0255142c6427e4f8f208083173a3ca71a2c00b687e8cb1c4f97f2c51e1eb8fd593cc0e51a6e32f8bd5590f7c6
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@mui/utils@npm:6.4.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:^7.2.21"
+    "@types/prop-types": "npm:^15.7.14"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6f21b58959eab2178e47ef6e6a95b2e1572705894f3705e97e3825d1dd289b9420308040507c64326aea68388ef89b712f8d123652f370b9041dbf965fd0dad6
   languageName: node
   linkType: hard
 
@@ -5038,10 +5076,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.13":
+"@types/prop-types@npm:^15.7.13":
   version: 15.7.13
   resolution: "@types/prop-types@npm:15.7.13"
   checksum: 10/8935cad87c683c665d09a055919d617fe951cb3b2d5c00544e3a913f861a2bd8d2145b51c9aa6d2457d19f3107ab40784c40205e757232f6a80cc8b1c815513c
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:^15.7.14":
+  version: 15.7.14
+  resolution: "@types/prop-types@npm:15.7.14"
+  checksum: 10/d0c5407b9ccc3dd5fae0ccf9b1007e7622ba5e6f1c18399b4f24dff33619d469da4b9fa918a374f19dc0d9fe6a013362aab0b844b606cfc10676efba3f5f736d
   languageName: node
   linkType: hard
 
@@ -5054,22 +5099,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:^4.4.11":
-  version: 4.4.11
-  resolution: "@types/react-transition-group@npm:4.4.11"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10/a7f4de6e5f57d9fcdea027e22873c633f96a803c96d422db8b99a45c36a9cceb7882d152136bbc31c7158fc1827e37aea5070d369724bb71dd11b5687332bc4d
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/ea14bc84f529a3887f9954b753843820ac8a3c49fcdfec7840657ecc6a8800aad98afdbe4b973eb96c7252286bde38476fcf64b1c09527354a9a9366e516d9a2
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.3.12
-  resolution: "@types/react@npm:18.3.12"
+"@types/react@npm:^19.0.8":
+  version: 19.0.8
+  resolution: "@types/react@npm:19.0.8"
   dependencies:
-    "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/c9bbdfeacd5347d2240e0d2cb5336bc57dbc1b9ff557b6c4024b49df83419e4955553518169d3736039f1b62608e15b35762a6c03d49bd86e33add4b43b19033
+  checksum: 10/1080d5b96ee0b4395f8f167ae6952f570088ee03bdce69f8237aab82c32d9bd2b71106f787bac17ba351acc4aba5e3454bafca51f2eb11d1562073b821e63d15
   languageName: node
   linkType: hard
 
@@ -10363,6 +10407,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-core-module@npm:^2.16.0":
+  version: 2.16.1
+  resolution: "is-core-module@npm:2.16.1"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10/452b2c2fb7f889cbbf7e54609ef92cf6c24637c568acc7e63d166812a0fb365ae8a504c333a29add8bdb1686704068caa7f4e4b639b650dde4f00a038b8941fb
+  languageName: node
+  linkType: hard
+
 "is-data-view@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-data-view@npm:1.0.1"
@@ -14639,6 +14692,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "react-is@npm:19.0.0"
+  checksum: 10/6cd3695c462ec3f0d4db98583f0c1b9a439248d60214f6c42c2b0e2951a1066339d0eefa74707f03484042e043fca87750282a35b652492c035f5f3da0d6498a
+  languageName: node
+  linkType: hard
+
 "react-markdown@npm:^9.0.1":
   version: 9.0.1
   resolution: "react-markdown@npm:9.0.1"
@@ -15097,7 +15157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -15107,6 +15167,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/c473506ee01eb45cbcfefb68652ae5759e092e6b0fb64547feadf9736a6394f258fbc6f88e00c5ca36d5477fbb65388b272432a3600fa223062e54333c156753
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.19.0":
+  version: 1.22.10
+  resolution: "resolve@npm:1.22.10"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/0a398b44da5c05e6e421d70108822c327675febb880eebe905587628de401854c61d5df02866ff34fc4cb1173a51c9f0e84a94702738df3611a62e2acdc68181
   languageName: node
   linkType: hard
 
@@ -15123,7 +15196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -15133,6 +15206,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/f345cd37f56a2c0275e3fe062517c650bb673815d885e7507566df589375d165bbbf4bdb6aa95600a9bc55f4744b81f452b5a63f95b9f10a72787dba3c90890a
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>":
+  version: 1.22.10
+  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/d4d878bfe3702d215ea23e75e0e9caf99468e3db76f5ca100d27ebdc527366fee3877e54bce7d47cc72ca8952fc2782a070d238bfa79a550eeb0082384c3b81a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes: https://github.com/mitodl/hq/issues/6636

### Description (What does it do?)
<!--- Describe your changes in detail -->

Migrates component styles to use [styled()](https://mui.com/system/styled/), replacing [@emotion/styled](https://emotion.sh/docs/styled).

`@emotion/styled` and `@emotion/react` remain installed as they are peer dependencies of `@mui/styled-engine`.

This implements variants and is an incremental step towards PigmentCSS. From the linked issue: "We have a [MIT Learn] branch with an initial migration to PigmentCSS: https://github.com/mitodl/mit-learn/compare/main...jk/6475-pigmentcss. An option was to migrate incrementally with Emotion and PigmentCSS running in parallel, however this produced build errors coming from Pigment's dependencies that have no stack trace to any of our code for debugging ([WyW-in-JS](https://wyw-in-js.dev/) in particular) and from within the obfuscated JS bundle, missing source mapping on the build output. These issues are resolvable, but will take time - the PigmentCSS documentation is very thin at the moment (we have [Migrating to PigmentCSS](https://mui.com/material-ui/migration/migrating-to-pigment-css/) and its repo [README](https://github.com/mui/pigment-css/blob/master/README.md)). Many of the repo [issues](https://github.com/mui/pigment-css/issues) remain open for a long time. There is evidence that the Material UI team is heavily invested in PigmentCSS, indeed it is planned to become the Material UI default styling engine in subsequent versions (currently Emotion). There is also a general trajectory towards styling engines that pre-compile JS to CSS at build time given their compatibility with React Server Components and subsequent performance benefit, however the PigmentCSS library is alpha at present and so presents a risk in adopting fully."

The wider goal is to migrate to zero-runtime CSS to avoid the performance hit on the main thread as declarations are produced during hydration.

The main increment on this branch is to apply variants, however MUI System `styled()` does not yet support [Styling based on runtime values](https://github.com/mui/pigment-css?tab=readme-ov-file#styling-based-on-runtime-values).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `yarn start` to fire up Storybook. All story pages and component variants should match https://mitodl.github.io/smoot-design/

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Leaving in draft for the moment as there are issues to be resolved:

- Media query breakpoints specified in variants are not being applied.
- ~~Small layout shifts on Button variants.~~
- Explicit any in Button.tsx (need to type create styled callback for reuse).

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
