### PR TITLE
Handle Errors in streaming response.

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,7 +14,7 @@ const config: StorybookConfig = {
 
   framework: "@storybook/react-webpack5",
 
-  staticDirs: ["./public"],
+  staticDirs: ["../storybook-public"],
 
   addons: [
     "@storybook/addon-links",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,18 @@
 import * as React from "react"
 import { Preview } from "@storybook/react"
 import { ThemeProvider } from "../src/components/ThemeProvider/ThemeProvider"
+import { initialize, mswLoader } from "msw-storybook-addon"
+
+const ALLOW_UNHANDLED_REQUESTS = [/use\.typekit/]
+// Initialize MSW
+initialize({
+  onUnhandledRequest(request, print) {
+    if (ALLOW_UNHANDLED_REQUESTS.some((regex) => regex.test(request.url))) {
+      return
+    }
+    print.warning()
+  },
+})
 
 const preview: Preview = {
   decorators: [
@@ -11,6 +23,7 @@ const preview: Preview = {
     ),
   ],
   tags: ["autodocs"],
+  loaders: [mswLoader],
 }
 
 export default preview

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config.InitialOptions = {
     "jest-watch-typeahead/testname",
   ],
   setupFilesAfterEnv: ["./jest-setup.ts"],
-  testEnvironment: "<rootDir>/jsdom-extended.ts",
+  testEnvironment: "jest-fixed-jsdom",
   transform: {
     "^.+\\.(t|j)sx?$": "@swc/jest",
   },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,10 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-extended": "^4.0.2",
     "jest-fail-on-console": "^3.3.1",
+    "jest-fixed-jsdom": "^0.0.9",
     "jest-watch-typeahead": "^2.2.2",
+    "msw": "^2.7.0",
+    "msw-storybook-addon": "^2.0.4",
     "next": "^15.0.2",
     "prettier": "^3.3.3",
     "react": "19.0.0",
@@ -141,5 +144,10 @@
     "@remixicon/react": "^4.2.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
+  },
+  "msw": {
+    "workerDirectory": [
+      "storybook-public"
+    ]
   }
 }

--- a/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.stories.tsx
+++ b/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { AiChatDrawer, ChatInitMessage } from "./RemoteAiChatDrawer"
 import invariant from "tiny-invariant"
+import { handlers } from "../../components/AiChat/test-utils/api"
 
 type ChatInitPayload = ChatInitMessage["payload"]
 
@@ -71,6 +72,11 @@ const meta: Meta<typeof AiChatDrawer> = {
         <AiChatDrawer messageOrigin="http://localhost:6006" />
       </>
     )
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
   },
 }
 

--- a/src/components/AiChat/AiChat.mdx
+++ b/src/components/AiChat/AiChat.mdx
@@ -12,6 +12,8 @@ for use with AI services. It can be used with text-streaming or JSON APIs.
 
 This demo shows the AiChat component with a simple text-streaming API.
 
+_Note: Sending the message `"error"` will cause the simulated API to return an error response._
+
 <Primary />
 
 ## Inputs

--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -2,9 +2,9 @@ import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { AiChat } from "./AiChat"
 import type { AiChatProps } from "./types"
-import { mockJson, mockStreaming } from "./story-utils"
 import styled from "@emotion/styled"
 import { fn } from "@storybook/test"
+import { handlers } from "./test-utils/api"
 
 const TEST_API_STREAMING = "http://localhost:4567/streaming"
 const TEST_API_JSON = "http://localhost:4567/json"
@@ -66,17 +66,22 @@ const meta: Meta<typeof AiChat> = {
       table: { readonly: true }, // See above
     },
   },
-  beforeEach: () => {
-    const originalFetch = window.fetch
-    window.fetch = (url, opts) => {
-      if (url === TEST_API_STREAMING) {
-        return mockStreaming()
-      } else if (url === TEST_API_JSON) {
-        return mockJson()
-      }
-      return originalFetch(url, opts)
-    }
+  parameters: {
+    msw: {
+      handlers,
+    },
   },
+  // beforeEach: () => {
+  //   const originalFetch = window.fetch
+  //   window.fetch = (url, opts) => {
+  //     if (url === TEST_API_STREAMING) {
+  //       return mockStreaming()
+  //     } else if (url === TEST_API_JSON) {
+  //       return mockJson()
+  //     }
+  //     return originalFetch(url, opts)
+  //   }
+  // },
 }
 
 export default meta

--- a/src/components/AiChat/AiChat.test.tsx
+++ b/src/components/AiChat/AiChat.test.tsx
@@ -7,22 +7,20 @@ import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import * as React from "react"
 import { AiChatProps } from "./types"
 import { faker } from "@faker-js/faker/locale/en"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
 
 const counter = jest.fn() // use jest.fn as counter because it resets on each test
-const mockFetch = jest.mocked(
-  jest.fn(() => {
+const API_URL = "http://localhost:4567/test"
+const server = setupServer(
+  http.post(API_URL, async () => {
     const count = counter.mock.calls.length
     counter()
-    return Promise.resolve(
-      new Response(`AI Response ${count}`, {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }),
-    )
-  }) as typeof fetch,
+    return HttpResponse.text(`AI Response ${count}`)
+  }),
 )
-window.fetch = mockFetch
+server.listen()
+
 jest.mock("react-markdown", () => {
   return {
     __esModule: true,
@@ -65,7 +63,7 @@ describe("AiChat", () => {
         data-testid="ai-chat"
         initialMessages={initialMessages}
         conversationStarters={conversationStarters}
-        requestOpts={{ apiUrl: "http://localhost:4567/test" }}
+        requestOpts={{ apiUrl: API_URL }}
         placeholder="Type a message..."
         {...props}
       />,
@@ -78,7 +76,7 @@ describe("AiChat", () => {
           data-testid="ai-chat"
           initialMessages={initialMessages}
           conversationStarters={conversationStarters}
-          requestOpts={{ apiUrl: "http://localhost:4567/test" }}
+          requestOpts={{ apiUrl: API_URL }}
           {...newProps}
         />,
       )
@@ -145,11 +143,11 @@ describe("AiChat", () => {
   })
 
   test("transformBody is called before sending requests", async () => {
+    const mockFetch = jest.spyOn(window, "fetch")
     const fakeBody = { message: faker.lorem.sentence() }
-    const apiUrl = faker.internet.url()
     const transformBody = jest.fn(() => fakeBody)
     const { initialMessages } = setup({
-      requestOpts: { apiUrl, transformBody },
+      requestOpts: { apiUrl: API_URL, transformBody },
     })
 
     await user.click(screen.getByPlaceholderText("Type a message..."))
@@ -162,7 +160,7 @@ describe("AiChat", () => {
     ])
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledWith(
-      apiUrl,
+      API_URL,
       expect.objectContaining({
         body: JSON.stringify(fakeBody),
       }),
@@ -171,10 +169,9 @@ describe("AiChat", () => {
 
   test("parseContent is called on the API-received message content", async () => {
     const fakeBody = { message: faker.lorem.sentence() }
-    const apiUrl = faker.internet.url()
     const transformBody = jest.fn(() => fakeBody)
     const { initialMessages, conversationStarters } = setup({
-      requestOpts: { apiUrl, transformBody },
+      requestOpts: { apiUrl: API_URL, transformBody },
       parseContent: jest.fn((content) => `Parsed: ${content}`),
     })
 
@@ -201,10 +198,9 @@ describe("AiChat", () => {
 
   test("Passes extra attributes to root", () => {
     const fakeBody = { message: faker.lorem.sentence() }
-    const apiUrl = faker.internet.url()
     const transformBody = jest.fn(() => fakeBody)
     setup({
-      requestOpts: { apiUrl, transformBody },
+      requestOpts: { apiUrl: API_URL, transformBody },
       parseContent: jest.fn((content) => `Parsed: ${content}`),
     })
     expect(screen.getByTestId("ai-chat")).toBeInTheDocument()

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames"
 import { SrAnnouncer } from "../SrAnnouncer/SrAnnouncer"
 import { VisuallyHidden } from "../VisuallyHidden/VisuallyHidden"
 import Typography from "@mui/material/Typography"
+import { Alert } from "../Alert/Alert"
 
 const classes = {
   root: "MitAiChat--root",
@@ -245,6 +246,7 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
     append,
     isLoading,
     stop,
+    error,
   } = useAiChat(requestOpts, {
     initialMessages: initialMessages,
     id: chatId,
@@ -266,7 +268,7 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
   const showStarters = messages.length === initialMessages.length
 
   const waiting =
-    !showStarters && messages[messages.length - 1]?.role === "user"
+    !showStarters && !error && messages[messages.length - 1]?.role === "user"
   const stoppable = isLoading && messages[messages.length - 1]?.role !== "user"
 
   const scrollToBottom = () => {
@@ -335,6 +337,11 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
               <RiMoreFill />
             </Message>
           </MessageRow>
+        ) : null}
+        {error ? (
+          <Alert severity="error" closable>
+            An unexpected error has occurred.
+          </Alert>
         ) : null}
       </MessagesContainer>
       <form

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -76,9 +76,21 @@ const getReadableStream = () => {
 }
 
 const handlers = [
-  http.post("http://localhost:4567/streaming", async () => {
+  http.post("http://localhost:4567/streaming", async ({ request }) => {
     await delay(600)
     const body = getReadableStream()
+
+    const requestBody = await request.json()
+    if (Array.isArray(requestBody)) {
+      const last = requestBody[requestBody.length - 1]
+      const { content } = last
+      if (content === "error") {
+        return new HttpResponse("Internal Server Error", {
+          status: 500,
+        })
+      }
+    }
+
     return new HttpResponse(body, {
       headers: {
         "Content-Type": "text/plain",

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import { Alert } from "./Alert"
+import Stack from "@mui/material/Stack"
+
+const meta: Meta<typeof Alert> = {
+  title: "smoot-design/Alert",
+  component: Alert,
+}
+
+export default meta
+
+type Story = StoryObj<typeof Alert>
+
+export const Basic: Story = {
+  args: {
+    severity: "info",
+  },
+  render: (args) => (
+    <Alert {...args}>Alert with severity "{args.severity}"</Alert>
+  ),
+}
+
+export const Closable: Story = {
+  args: {
+    severity: "warning",
+    closable: true,
+  },
+  render: (args) => (
+    <Alert {...args}>Closable alert with severity "{args.severity}"</Alert>
+  ),
+}
+
+export const Variants: Story = {
+  argTypes: {
+    severity: {
+      table: {
+        disable: true,
+      },
+    },
+    closable: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: (args) => (
+    <Stack direction="column" gap={2} sx={{ my: 2 }}>
+      <Alert {...args} severity="info">
+        Alert with severity "info"
+      </Alert>
+      <Alert {...args} closable severity="info">
+        Closable alert with severity "info"
+      </Alert>
+      <Alert {...args} severity="success">
+        Alert with severity "success"
+      </Alert>
+      <Alert {...args} closable severity="success">
+        Closable alert with severity "success"
+      </Alert>
+      <Alert {...args} severity="warning">
+        Alert with severity "warning"
+      </Alert>
+      <Alert {...args} closable severity="warning">
+        Closable alert with severity "warning"
+      </Alert>
+      <Alert {...args} severity="error">
+        Alert with severity "error"
+      </Alert>
+      <Alert {...args} closable severity="error">
+        Closable alert with severity "error"
+      </Alert>
+    </Stack>
+  ),
+}

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import * as React from "react"
+
+import styled from "@emotion/styled"
+import { default as MuiAlert } from "@mui/material/Alert"
+import type { AlertColor } from "@mui/material/Alert"
+import { Theme } from "@emotion/react"
+
+const getColor = (theme: Theme, severity: AlertColor) => {
+  return {
+    info: theme.custom.colors.blue,
+    success: theme.custom.colors.green,
+    warning: theme.custom.colors.orange,
+    error: theme.custom.colors.lightRed,
+  }[severity]
+}
+
+type AlertStyleProps = {
+  severity: AlertColor
+}
+
+const AlertStyled = styled(MuiAlert)<AlertStyleProps>(
+  ({ theme, severity }) => ({
+    padding: "11px 16px",
+    borderRadius: 4,
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderColor: getColor(theme, severity),
+    background: "#FFF",
+    ".MuiAlert-message": {
+      ...theme.typography.body2,
+      color: theme.custom.colors.darkGray2,
+      alignSelf: "center",
+    },
+    "> div": {
+      paddingTop: 0,
+      paddingBottom: 0,
+    },
+    ".MuiAlert-icon": {
+      marginRight: 8,
+      svg: {
+        width: 16,
+        fill: getColor(theme, severity),
+      },
+    },
+    button: {
+      padding: 0,
+      ":hover": {
+        margin: 0,
+        background: "none",
+      },
+    },
+  }),
+)
+
+const Hidden = styled.span({ display: "none" })
+
+type AlertProps = {
+  visible?: boolean
+  closable?: boolean
+  className?: string
+  severity?: AlertColor
+  /**
+   * Alert Content
+   */
+  children?: React.ReactNode
+}
+
+const Alert: React.FC<AlertProps> = ({
+  visible = true,
+  severity = "info",
+  closable,
+  children,
+  className,
+}) => {
+  const [_visible, setVisible] = React.useState(visible)
+  const id = React.useId()
+  const onCloseClick = () => {
+    setVisible(false)
+  }
+
+  React.useEffect(() => {
+    setVisible(visible)
+  }, [visible])
+
+  if (!_visible) {
+    return null
+  }
+
+  return (
+    <AlertStyled
+      severity={severity!}
+      onClose={closable ? onCloseClick : undefined}
+      role="alert"
+      aria-describedby={id}
+      className={className}
+    >
+      {children}
+      <Hidden id={id}>{severity} message</Hidden>
+    </AlertStyled>
+  )
+}
+
+export { Alert }
+export type { AlertProps }

--- a/storybook-public/mockServiceWorker.js
+++ b/storybook-public/mockServiceWorker.js
@@ -1,0 +1,307 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = "2.7.0"
+const INTEGRITY_CHECKSUM = "00729d72e3b82faf54ca8b9621dbb96f" // pragma: allowlist secret
+const IS_MOCKED_RESPONSE = Symbol("isMockedResponse")
+const activeClientIds = new Set()
+
+self.addEventListener("install", function () {
+  self.skipWaiting()
+})
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener("message", async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  })
+
+  switch (event.data) {
+    case "KEEPALIVE_REQUEST": {
+      sendToClient(client, {
+        type: "KEEPALIVE_RESPONSE",
+      })
+      break
+    }
+
+    case "INTEGRITY_CHECK_REQUEST": {
+      sendToClient(client, {
+        type: "INTEGRITY_CHECK_RESPONSE",
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: "MOCKING_ENABLED",
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener("fetch", function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === "navigate") {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: "RESPONSE",
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === "top-level") {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === "visible"
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get("accept")
+    if (acceptHeader) {
+      const values = acceptHeader.split(",").map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== "msw/passthrough",
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set("accept", filteredValues.join(", "))
+      } else {
+        headers.delete("accept")
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: "REQUEST",
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case "MOCK_RESPONSE": {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case "PASSTHROUGH": {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,6 +1510,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bundled-es-modules/cookie@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@bundled-es-modules/cookie@npm:2.0.1"
+  dependencies:
+    cookie: "npm:^0.7.2"
+  checksum: 10/0038a5e82c41bfcd722afedabeb6961a5f15747b3681d7f4b61e35eb1e33130039e10ee9250dc9c9e4d3915ce1aeee717c0fb92225111574f0a030411abc0987
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/statuses@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@bundled-es-modules/statuses@npm:1.0.1"
+  dependencies:
+    statuses: "npm:^2.0.1"
+  checksum: 10/9bf6a2bcf040a66fb805da0e1446041fd9def7468bb5da29c5ce02adf121a3f7cec123664308059a62a46fcaee666add83094b76df6dce72e5cafa8e6bebe60d
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/tough-cookie@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "@bundled-es-modules/tough-cookie@npm:0.1.6"
+  dependencies:
+    "@types/tough-cookie": "npm:^4.0.5"
+    tough-cookie: "npm:^4.1.4"
+  checksum: 10/4f24a820f02c08c3ca0ff21272317357152093f76f9c8cc182517f61fa426ae53dadc4d68a3d6da5078e8d73f0ff8c0907a9f994c0be756162ba9c7358533e57
+  languageName: node
+  linkType: hard
+
 "@chromatic-com/storybook@npm:^3.0.0":
   version: 3.2.3
   resolution: "@chromatic-com/storybook@npm:3.2.3"
@@ -2288,6 +2316,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/confirm@npm:^5.0.0":
+  version: 5.1.6
+  resolution: "@inquirer/confirm@npm:5.1.6"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.7"
+    "@inquirer/type": "npm:^3.0.4"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/445314a5472a4df2a95f8e44a0d214ed89b13344077433e29b28933f6d360fda567bed4b7cbdb32a97fca52be2ad2f655f4103f6aaa43c37a40ab53b150251e8
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.1.7":
+  version: 10.1.7
+  resolution: "@inquirer/core@npm:10.1.7"
+  dependencies:
+    "@inquirer/figures": "npm:^1.0.10"
+    "@inquirer/type": "npm:^3.0.4"
+    ansi-escapes: "npm:^4.3.2"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/9c016d92ab00749c8cc35a958266e696bfa12dfd1455875ca749fbee3f39b38e55be49634bc19a2fdadd3d2b73a561eb8ea42dffedb4fcffde3d9a485cf21997
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "@inquirer/figures@npm:1.0.10"
+  checksum: 10/ecdeb3e23722375fd634d93a75e5d642fa7fdb0af90c001058054bd9817fb23062ef01039e6a994d6c9427e472b50a1fd1950775c26b9e5103aa1e64cfd5fdd4
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@inquirer/type@npm:3.0.4"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/64ec072d2725ee31586af65cf32f553f217978f7020011d049e663b45776ff8c72aefe18eb12ece46788eaef9b239fc3bd01edfbe1d07b9162cc97aae5c173fb
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2705,8 +2788,11 @@ __metadata:
     jest-environment-jsdom: "npm:^29.5.0"
     jest-extended: "npm:^4.0.2"
     jest-fail-on-console: "npm:^3.3.1"
+    jest-fixed-jsdom: "npm:^0.0.9"
     jest-watch-typeahead: "npm:^2.2.2"
     lodash: "npm:^4.17.21"
+    msw: "npm:^2.7.0"
+    msw-storybook-addon: "npm:^2.0.4"
     next: "npm:^15.0.2"
     prettier: "npm:^3.3.3"
     react: "npm:19.0.0"
@@ -2733,6 +2819,20 @@ __metadata:
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
+
+"@mswjs/interceptors@npm:^0.37.0":
+  version: 0.37.6
+  resolution: "@mswjs/interceptors@npm:0.37.6"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10/bc1541ba3b8b04db267cb962542752383245cb55b074b1eeee4c9fb03ccb8713b0c4b55eab46af2bc161b9893d8a25998894f88e3f2e3feab5f092c4d7c416cb
+  languageName: node
+  linkType: hard
 
 "@mui/core-downloads-tracker@npm:^6.1.6":
   version: 6.1.6
@@ -3399,6 +3499,30 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^22.2.0"
   checksum: 10/9ea6189839439e1085799cc16ee699292538d9c14dd15e9e45462377287f863b6be93455d2ad9acffd561018a0c35adbb9d1437e92075c9058d6c6d69ff2f503
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10/bc3bb1668a555bb87b33383cafcf207d9561e17d2ca0d9e61b7ce88e82b66e36a333d3676c1d39eb5848022c03c8145331fcdc828ba297f88cb1de9c5cef6c19
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10/7a280f170bcd4e91d3eedbefe628efd10c3bd06dd2461d06a7fdbced89ef457a38785847f88cc630fb4fd7dfa176d6f77aed17e5a9b08000baff647433b5ff78
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0, @open-draft/until@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10/622be42950afc8e89715d0fd6d56cbdcd13e36625e23b174bd3d9f06f80e25f9adf75d6698af93bca1e1bf465b9ce00ec05214a12189b671fb9da0f58215b6f4
   languageName: node
   linkType: hard
 
@@ -4826,6 +4950,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookie@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@types/cookie@npm:0.6.0"
+  checksum: 10/b883348d5bf88695fbc2c2276b1c49859267a55cae3cf11ea1dccc1b3be15b466e637ce3242109ba27d616c77c6aa4efe521e3d557110b4fdd9bc332a12445c2
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -5104,6 +5235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/statuses@npm:^2.0.4":
+  version: 2.0.5
+  resolution: "@types/statuses@npm:2.0.5"
+  checksum: 10/3f2609f660b45a878c6782f2fb2cef9f08bbd4e89194bf7512e747b8a73b056839be1ad6f64b1353765528cd8a5e93adeffc471cde24d0d9f7b528264e7154e5
+  languageName: node
+  linkType: hard
+
 "@types/supports-color@npm:^8.0.0":
   version: 8.1.3
   resolution: "@types/supports-color@npm:8.1.3"
@@ -5111,7 +5249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tough-cookie@npm:*":
+"@types/tough-cookie@npm:*, @types/tough-cookie@npm:^4.0.5":
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10/01fd82efc8202670865928629697b62fe9bf0c0dcbc5b1c115831caeb073a2c0abb871ff393d7df1ae94ea41e256cb87d2a5a91fd03cdb1b0b4384e08d4ee482
@@ -5814,7 +5952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1":
+"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -6983,6 +7121,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
+  languageName: node
+  linkType: hard
+
 "client-only@npm:0.0.1, client-only@npm:^0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
@@ -7272,6 +7417,13 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 10/c987be3ec061348cdb3c2bfb924bec86dea1eacad10550a85ca23edb0fe3556c3a61c7399114f3331ccb3499d7fd0285ab24566e5745929412983494c3926e15
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
   languageName: node
   linkType: hard
 
@@ -9650,6 +9802,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql@npm:^16.8.1":
+  version: 16.10.0
+  resolution: "graphql@npm:16.10.0"
+  checksum: 10/d42cf81ddcf3a61dfb213217576bf33c326f15b02c4cee369b373dc74100cbdcdc4479b3b797e79b654dabd8fddf50ef65ff75420e9ce5596c02e21f24c9126a
+  languageName: node
+  linkType: hard
+
 "handlebars@npm:^4.7.7":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
@@ -9799,6 +9958,13 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10/d09b2243da4e23f53336e8de3093e5c43d2c39f8d0d18817abfa32ce3e9355391b2edb4bb5edc376aea5d4b0b59d6a0482aab4c52bc02ef95751e4b818e847f1
+  languageName: node
+  linkType: hard
+
+"headers-polyfill@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "headers-polyfill@npm:4.0.3"
+  checksum: 10/3a008aa2ef71591e2077706efb48db1b2729b90cf646cc217f9b69744e35cca4ba463f39debb6000904aa7de4fada2e5cc682463025d26bcc469c1d99fa5af27
   languageName: node
   linkType: hard
 
@@ -10514,6 +10680,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-node-process@npm:^1.0.1, is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10/930765cdc6d81ab8f1bbecbea4a8d35c7c6d88a3ff61f3630e0fc7f22d624d7661c1df05c58547d0eb6a639dfa9304682c8e342c4113a6ed51472b704cee2928
+  languageName: node
+  linkType: hard
+
 "is-number-object@npm:^1.0.4":
   version: 1.0.7
   resolution: "is-number-object@npm:1.0.7"
@@ -11004,6 +11177,15 @@ __metadata:
   version: 3.3.1
   resolution: "jest-fail-on-console@npm:3.3.1"
   checksum: 10/59d72906c20390dcd79be51c2ff0d65fe66fb68c2a4633339b95c3bd5dce5745adb06ac91b095de03f367cc2b4d6868d44abf97e1fb21d7e7835a9710b0630cd
+  languageName: node
+  linkType: hard
+
+"jest-fixed-jsdom@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "jest-fixed-jsdom@npm:0.0.9"
+  peerDependencies:
+    jest-environment-jsdom: ">=28.0.0"
+  checksum: 10/c0c1502c81de2c628f728d4c8cff1d66adf7dba3933d72198905bd395b95d393cc535d36469076e03c32f8f0c2200bffcc61065de0a4e5d6f83cfccad0da95cb
   languageName: node
   linkType: hard
 
@@ -12912,6 +13094,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msw-storybook-addon@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "msw-storybook-addon@npm:2.0.4"
+  dependencies:
+    is-node-process: "npm:^1.0.1"
+  peerDependencies:
+    msw: ^2.0.0
+  checksum: 10/63a7bd165190e332e31d5a8b4503af4e6361b81d59e504f97c474327e69021a014094de281859e0c41368e269dac9cd46cebb071e54cd13fce8505f24b08a504
+  languageName: node
+  linkType: hard
+
+"msw@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "msw@npm:2.7.0"
+  dependencies:
+    "@bundled-es-modules/cookie": "npm:^2.0.1"
+    "@bundled-es-modules/statuses": "npm:^1.0.1"
+    "@bundled-es-modules/tough-cookie": "npm:^0.1.6"
+    "@inquirer/confirm": "npm:^5.0.0"
+    "@mswjs/interceptors": "npm:^0.37.0"
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/until": "npm:^2.1.0"
+    "@types/cookie": "npm:^0.6.0"
+    "@types/statuses": "npm:^2.0.4"
+    graphql: "npm:^16.8.1"
+    headers-polyfill: "npm:^4.0.2"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    strict-event-emitter: "npm:^0.5.1"
+    type-fest: "npm:^4.26.1"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10/165ccf37d90da0d5271fdb8e01f89f48f7a60fb810038ff73d18c0e5e5ddfdb1266002d19cde61b9ae689ef37c39499b10d9d07e0d16662a31630ce9adce1d77
+  languageName: node
+  linkType: hard
+
 "mute-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "mute-stream@npm:2.0.0"
@@ -13606,6 +13832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10/3a7582745850cb344d49641867a4c080858c54f4091afd91b9c0765ba6e471c2bc841348f0fff344845ddd0a4db42fd5d68c6f7ebaf32d4b676a3a9987b2488a
+  languageName: node
+  linkType: hard
+
 "p-each-series@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-each-series@npm:3.0.0"
@@ -14038,6 +14271,13 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10/6822f686f01556d99538b350722ef761541ec0ce95ca40ce4c29e20a5b492fe8361961f57993c71b2418de12e604478dcf7c430de34b2c31a688363a7a944d9c
   languageName: node
   linkType: hard
 
@@ -15925,6 +16165,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 10/18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
 "storybook@npm:^8.4.2":
   version: 8.4.2
   resolution: "storybook@npm:8.4.2"
@@ -15979,6 +16226,13 @@ __metadata:
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
   checksum: 10/612c2b2a7dbcc859f74597112f80a42cbe4d448d03da790d5b7b39673c1197dd3789e91cd67210353e58857395d32c1e955a9041c4e6d5bae723436b3ed9ed14
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10/25c84d88be85940d3547db665b871bfecea4ea0bedfeb22aae8db48126820cfb2b0bc2fba695392592a09b1aa36b686d6eede499e1ecd151593c03fe5a50d512
   languageName: node
   linkType: hard
 
@@ -16571,7 +16825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^4.1.2":
+"tough-cookie@npm:^4.1.2, tough-cookie@npm:^4.1.4":
   version: 4.1.4
   resolution: "tough-cookie@npm:4.1.4"
   dependencies:
@@ -17707,6 +17961,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/0d64f2d438e0b555e693b95aee7b2689a12c3be5ac458192a1ce28f542a6e9e59ddfecc37520910c2c88eb1f82a5411260566dba5064e8f9895e76e169e76187
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -17854,7 +18119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.5.1":
+"yargs@npm:^17.3.1, yargs@npm:^17.5.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -17887,6 +18152,13 @@ __metadata:
   version: 1.1.1
   resolution: "yocto-queue@npm:1.1.1"
   checksum: 10/f2e05b767ed3141e6372a80af9caa4715d60969227f38b1a4370d60bffe153c9c5b33a862905609afc9b375ec57cd40999810d20e5e10229a204e8bde7ef255c
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "yoctocolors-cjs@npm:2.1.2"
+  checksum: 10/d731e3ba776a0ee19021d909787942933a6c2eafb2bbe85541f0c59aa5c7d475ce86fcb860d5803105e32244c3dd5ba875b87c4c6bf2d6f297da416aa54e556f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6641

### Description (What does it do?)
This PR:
- switches to MSW for network mocking in storybook and tests.
- Adds the Alert component from MIT Learn
- Shows an Alert when a network error occurs during streaming

### Screenshots (if appropriate):
<img width="819" alt="Screenshot 2025-02-19 at 4 06 10 PM" src="https://github.com/user-attachments/assets/e8df149a-3b60-465a-80f3-34e8d5c33d55" />


### How can this be tested?
After running `yarn install` and `yarn start`:
1. Visit http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs and chat with the fake AI. It should work.
2. Now send the AI the message `"error"`. You'll see a 500 error in the network tab and an alert will show.
3. The storybook pages also now support "Stop streaming". So when a message is streaming, if you press "Stop", it the response should stop as expected.