### PR TITLE
feat: AiChat UI changes

### DIFF
--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -90,3 +90,40 @@ export const JsonResponses: Story = {
     },
   },
 }
+
+const DEMO_MARKDOWN = `This shows default markdown styling. Here's a list:
+- Item 1 lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+- Item 2
+- Item 3
+    - Item 3.1
+    - Item 3.2
+- Item 4
+    1. Item 4.1
+    2. Item 4.2
+    3. Item 4.3
+
+Here is a longer paragraph and **bold text** and *italic text*. Lorem ipsum dolor sit amet, consectetur adipiscing elit
+sed do eiusmod tempor [incididunt](https://mit.edu) ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+
+And some inline code, \`\`<inline></inline>\`\` and code block:
+\`\`\`
+def f(x):
+    print(x)
+\`\`\`
+`
+
+/**
+ * This story shows the component's builtin markdown styling.
+ */
+export const MarkdownStyling: Story = {
+  args: {
+    title: "Markdown Styles",
+    requestOpts: { apiUrl: TEST_API_STREAMING },
+    initialMessages: [
+      {
+        role: "assistant",
+        content: DEMO_MARKDOWN,
+      },
+    ],
+  },
+}

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -155,14 +155,8 @@ const RobotIcon = styled(RiRobot2Line)({
 })
 
 const StyledInput = styled(Input)(({ theme }) => ({
-  backgroundColor: theme.custom.colors.lightGray1,
   borderRadius: "8px",
   border: `1px solid ${theme.custom.colors.lightGray2}`,
-  ":hover, :focus-within": {
-    svg: {
-      fill: theme.custom.colors.lightRed,
-    },
-  },
 }))
 
 const StyledSendButton = styled(RiSendPlaneFill)(({ theme }) => ({

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -30,6 +30,7 @@ const classes = {
   messageRowAssistant: "MitAiChat--messageRowAssistant",
   message: "MitAiChat--message",
   input: "MitAiChat--input",
+  bottomSection: "MitAiChat--bottomSection",
 }
 
 const ChatContainer = styled.div({
@@ -66,8 +67,7 @@ const MessagesContainer = styled(ScrollSnap)({
   display: "flex",
   flexDirection: "column",
   flex: 1,
-  paddingTop: "14px",
-  paddingBottom: "24px",
+  padding: "14px 0",
   overflow: "auto",
   gap: "16px",
 })
@@ -98,11 +98,13 @@ const Message = styled.div(({ theme }) => ({
   "p:last-of-type": {
     marginBottom: 0,
   },
-  ol: {
+  "ol, ul": {
     paddingInlineStart: "32px",
+    li: {
+      margin: "16px 0",
+    },
   },
   ul: {
-    paddingInlineStart: "32px",
     marginInlineStart: "-16px",
   },
   a: {
@@ -156,6 +158,11 @@ const StyledInput = styled(Input)(({ theme }) => ({
   backgroundColor: theme.custom.colors.lightGray1,
   borderRadius: "8px",
   border: `1px solid ${theme.custom.colors.lightGray2}`,
+  ":hover, :focus-within": {
+    svg: {
+      fill: theme.custom.colors.lightRed,
+    },
+  },
 }))
 
 const StyledSendButton = styled(RiSendPlaneFill)(({ theme }) => ({
@@ -166,9 +173,13 @@ const StyledStopButton = styled(RiStopFill)(({ theme }) => ({
   fill: theme.custom.colors.red,
 }))
 
+const BottomSection = styled.div({
+  paddingTop: "12px",
+})
+
 const Disclaimer = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
-  marginTop: "16px",
+  marginTop: "14px",
   textAlign: "center",
 }))
 
@@ -351,54 +362,55 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
           </Alert>
         ) : null}
       </MessagesContainer>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          if (isLoading && stoppable) {
-            stop()
-          } else {
-            scrollToBottom()
-            handleSubmit(e)
-          }
-        }}
-      >
-        <StyledInput
-          fullWidth
-          size="chat"
-          className={classes.input}
-          placeholder={placeholder}
-          name="message"
-          sx={{ flex: 1 }}
-          value={input}
-          onChange={handleInputChange}
-          endAdornment={
-            isLoading ? (
-              <AdornmentButton
-                aria-label="Stop"
-                onClick={stop}
-                disabled={!stoppable}
-              >
-                <StyledStopButton />
-              </AdornmentButton>
-            ) : (
-              <AdornmentButton
-                aria-label="Send"
-                type="submit"
-                disabled={!input}
-                onClick={(e) => {
-                  scrollToBottom()
-                  handleSubmit(e)
-                }}
-              >
-                <StyledSendButton />
-              </AdornmentButton>
-            )
-          }
-        />
-      </form>
-      <Disclaimer variant="body3">
-        AI-generated content may be incorrect.
-      </Disclaimer>
+      <BottomSection className={classes.bottomSection}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (isLoading && stoppable) {
+              stop()
+            } else {
+              scrollToBottom()
+              handleSubmit(e)
+            }
+          }}
+        >
+          <StyledInput
+            fullWidth
+            size="chat"
+            className={classes.input}
+            placeholder={placeholder}
+            name="message"
+            sx={{ flex: 1 }}
+            value={input}
+            onChange={handleInputChange}
+            endAdornment={
+              isLoading ? (
+                <AdornmentButton
+                  aria-label="Stop"
+                  onClick={stop}
+                  disabled={!stoppable}
+                >
+                  <StyledStopButton />
+                </AdornmentButton>
+              ) : (
+                <AdornmentButton
+                  aria-label="Send"
+                  type="submit"
+                  onClick={(e) => {
+                    scrollToBottom()
+                    handleSubmit(e)
+                  }}
+                >
+                  <StyledSendButton />
+                </AdornmentButton>
+              )
+            }
+          />
+        </form>
+        <Disclaimer variant="body3">
+          AI-generated content may be incorrect.
+        </Disclaimer>
+      </BottomSection>
       <SrAnnouncer
         isLoading={isLoading}
         loadingMessages={srLoadingMessages}

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -113,12 +113,7 @@ const Message = styled.div(({ theme }) => ({
   },
   borderRadius: "12px",
   [`.${classes.messageRowAssistant} &`]: {
-    border: `1px solid ${theme.custom.colors.lightGray2}`,
-    borderRadius: "0px 8px 8px 8px",
-    svg: {
-      fill: theme.custom.colors.silverGrayDark,
-      display: "block",
-    },
+    padding: "12px 16px 12px 0",
   },
   [`.${classes.messageRowUser} &`]: {
     borderRadius: "8px 0px 8px 8px",

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -69,7 +69,7 @@ const MessagesContainer = styled(ScrollSnap)({
   paddingTop: "14px",
   paddingBottom: "24px",
   overflow: "auto",
-  gap: "24px",
+  gap: "16px",
 })
 
 const MessageRow = styled.div<{
@@ -97,6 +97,13 @@ const Message = styled.div(({ theme }) => ({
   },
   "p:last-of-type": {
     marginBottom: 0,
+  },
+  ol: {
+    paddingInlineStart: "32px",
+  },
+  ul: {
+    paddingInlineStart: "32px",
+    marginInlineStart: "-16px",
   },
   a: {
     color: theme.custom.colors.red,

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -154,11 +154,6 @@ const RobotIcon = styled(RiRobot2Line)({
   height: "40px",
 })
 
-const StyledInput = styled(Input)(({ theme }) => ({
-  borderRadius: "8px",
-  border: `1px solid ${theme.custom.colors.lightGray2}`,
-}))
-
 const StyledSendButton = styled(RiSendPlaneFill)(({ theme }) => ({
   fill: theme.custom.colors.red,
 }))
@@ -368,7 +363,7 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
             }
           }}
         >
-          <StyledInput
+          <Input
             fullWidth
             size="chat"
             className={classes.input}

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -30,6 +30,19 @@ Here are some courses on linear algebra that you can explore:
 These courses provide a comprehensive introduction to linear algebra and its applications across various fields.
 <!-- Comment! -->
 `,
+  `Here are some courses on quantum computing that offer certificates:
+
+1. [Introduction to Quantum Computing](https://xpro.mit.edu/courses/course-v1:xPRO+QCFx1/)
+   - **Description**: This is the first course in the Quantum Computing Fundamentals professional certificate program. You can earn a Professional Certificate and CEUs by completing both courses in the program. Alternatively, you can take this course individually for a certificate of completion and CEUs.
+   - **Offered by**: MIT xPRO
+   - **Instructors**: Isaac Chuang, William Oliver, Peter Shor, Aram Harrow
+
+2. [Practical Realities of Quantum Computation and Quantum Communication](https://xpro.mit.edu/courses/course-v1:xPRO+QCRx1/)
+   - **Description**: This course is part of the Quantum Computing Realities professional certificate program. Completing both courses in the program will earn you a Professional Certificate and CEUs. You can also take this course individually for a certificate of completion and CEUs.
+   - **Offered by**: MIT xPRO
+   - **Instructors**: Isaac Chuang, William Oliver, Peter Shor, Aram Harrow
+
+These courses are part of professional certificate programs, and you can choose to complete the entire program or take individual courses for certification.`,
 ]
 
 const rand = (min: number, max: number) => {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -42,7 +42,7 @@ const responsiveSize: Record<Size, Size> = {
   small: "small",
   medium: "small",
   large: "medium",
-  chat: "medium",
+  chat: "chat",
   hero: "large",
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -116,6 +116,7 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
     size === "chat" && {
       padding: "0 16px",
       borderRadius: "8px",
+      borderColor: theme.custom.colors.silverGrayLight,
       "&:hover:not(.Mui-disabled), &.Mui-focused, :hover:not(.Mui-disabled):not(.Mui-focused)":
         {
           boxShadow: "0px 8px 20px 0px rgba(120, 147, 172, 0.10)",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -116,13 +116,15 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
     size === "chat" && {
       padding: "0 16px",
       borderRadius: "8px",
-      "&:hover:not(.Mui-disabled):not(.Mui-focused)": {
-        borderColor: theme.custom.colors.silverGrayLight,
-      },
-      "&.Mui-focused": {
-        borderColor: theme.custom.colors.silverGrayLight,
-        outline: "none",
-      },
+      "&:hover:not(.Mui-disabled), &.Mui-focused, :hover:not(.Mui-disabled):not(.Mui-focused)":
+        {
+          boxShadow: "0px 8px 20px 0px rgba(120, 147, 172, 0.10)",
+          borderColor: theme.custom.colors.silverGray,
+          outline: "none",
+          svg: {
+            fill: theme.custom.colors.lightRed,
+          },
+        },
       ".Mit-AdornmentButton": {
         padding: "0 16px",
       },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://github.com/mitodl/hq/issues/6815

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Applies the design updates in the linked issue that relate to the chat component.
- Provides a container for the AiChat input and disclaimer with classname for selecting in calling components.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`yarn start` and navigate to http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs

- The chat input should be styled according to [Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=16926-56822&t=65uU7nSD9tpEPcrh-0) on hover. The disabled state on the send adornment is removed on feedback that it should not look disabled on first load. Hover styles are also applied when focused. 

<img width="993" alt="image" src="https://github.com/user-attachments/assets/2ddf0834-d3cc-4cf4-8392-eb7ea3bff2f4" />


<img width="991" alt="image" src="https://github.com/user-attachments/assets/fdebbb9c-5af1-405b-9d43-29688fc1cffd" />




- Updated padding on \<ol\> and \<ul\> lists rendered from markdown chat messages. Change includes a mock message with nested lists (send a few messages until you get "Here are some courses on quantum computing..." 1 in 4).

<img width="714" alt="image" src="https://github.com/user-attachments/assets/66800681-96df-4614-ad4b-3c8b1cbc5145" />

- The send input does not take a smaller size at mobile screen widths.

- Assistant message border removed: 

<img width="985" alt="image" src="https://github.com/user-attachments/assets/ad66a309-4954-492d-9631-3c4fdba7dc2c" />

