### PR TITLE
feat: remoteAiChatDrawer style updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     }
   },
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@mui/utils": "^6.1.6",
     "ai": "^4.0.13",
     "classnames": "^2.5.1",

--- a/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
+++ b/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
@@ -70,7 +70,7 @@ const AiChatDrawer: React.FC<AiChatDrawerProps> = ({
       className={className}
       PaperProps={{
         sx: {
-          width: "600px",
+          width: "900px",
           maxWidth: "100%",
           boxSizing: "border-box",
           padding: "24px 40px",

--- a/src/bundles/remoteAiChatDrawer.tsx
+++ b/src/bundles/remoteAiChatDrawer.tsx
@@ -2,16 +2,45 @@ import * as React from "react"
 import { createRoot } from "react-dom/client"
 import { AiChatDrawer } from "./RemoteAiChatDrawer/RemoteAiChatDrawer"
 import type { AiChatDrawerProps } from "./RemoteAiChatDrawer/RemoteAiChatDrawer"
-import { ThemeProvider } from "../components/ThemeProvider/ThemeProvider"
+import {
+  ThemeProvider,
+  createTheme,
+} from "../components/ThemeProvider/ThemeProvider"
+import { CacheProvider } from "@emotion/react"
+import createCache from "@emotion/cache"
 
+/**
+ * Renders the AiChatDrawer in an shadow DOM in order to isolate the drawer
+ * styles from external stylesheets.
+ */
 const init = (opts: AiChatDrawerProps) => {
-  const root = document.createElement("div")
-  root.id = "smoot-chat-drawer-root"
-  document.body.append(root)
-  createRoot(root).render(
-    <ThemeProvider>
-      <AiChatDrawer {...opts} />
-    </ThemeProvider>,
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const shadowContainer = container.attachShadow({ mode: "open" })
+  const shadowRootEl = document.createElement("div")
+  shadowRootEl.id = "smoot-chat-drawer-root"
+  shadowContainer.append(shadowRootEl)
+  // See https://mui.com/material-ui/customization/shadow-dom/
+  // Ensure style tags are rendered in shadow root
+  const cache = createCache({
+    key: "css",
+    prepend: true,
+    container: shadowContainer,
+  })
+  const theme = createTheme({
+    components: {
+      // Ensure modals, etc, are rendered in shadow root
+      MuiPopover: { defaultProps: { container: shadowRootEl } },
+      MuiPopper: { defaultProps: { container: shadowRootEl } },
+      MuiModal: { defaultProps: { container: shadowRootEl } },
+    },
+  })
+  createRoot(shadowRootEl).render(
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={theme}>
+        <AiChatDrawer {...opts} />
+      </ThemeProvider>
+    </CacheProvider>,
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,6 +1610,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/sheet": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@emotion/weak-memoize": "npm:^0.4.0"
+    stylis: "npm:4.2.0"
+  checksum: 10/52336b28a27b07dde8fcdfd80851cbd1487672bbd4db1e24cca1440c95d8a6a968c57b0453c2b7c88d9b432b717f99554dbecc05b5cdef27933299827e69fd8e
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.9.2":
   version: 0.9.2
   resolution: "@emotion/hash@npm:0.9.2"
@@ -1714,6 +1727,13 @@ __metadata:
   version: 1.4.1
   resolution: "@emotion/utils@npm:1.4.1"
   checksum: 10/95e56fc0c9e05cf01a96268f0486ce813f1109a8653d2f575c67df9e8765d9c1b2daf09ad1ada67d933efbb08ca7990228e14b210c713daf90156b4869abe6a7
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10/e5f3b8bca066b3361a7ad9064baeb9d01ed1bf51d98416a67359b62cb3affec6bb0249802c4ed11f4f8030f93cc4b67506909420bdb110adec6983d712897208
   languageName: node
   linkType: hard
 
@@ -2739,6 +2759,7 @@ __metadata:
   resolution: "@mitodl/smoot-design@workspace:."
   dependencies:
     "@chromatic-com/storybook": "npm:^3.0.0"
+    "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6827

### Description (What does it do?)
This PR does two things:
1. Makes the drawer a bit wider, 900px on wide screens instead of 600px
2. Isolates the styles by putting the app root in a shadow DOM.

### Screenshots (if appropriate):
<img width="1713" alt="Screenshot 2025-03-03 at 3 39 27 PM" src="https://github.com/user-attachments/assets/639878c8-fdc2-4b9b-96e3-02d5aba9ba4d" />



### How can this be tested?
1. Run `yarn bundle-preview` locally
2. Navigate to http://localhost:3000/bundle-demo and click "Open Drawer".
    - The drawer should open
    - If you inspect the DOM, you should see that the model and its contents are inside a shadow root.

