### PR TITLE
feat: add requestBody to message events 

### DIFF
--- a/bundle-preview/bundle-demo.html
+++ b/bundle-preview/bundle-demo.html
@@ -16,10 +16,8 @@
     <iframe src="./iframe.html"></iframe>
   </body>
   <script>
-    const el = document.getElementById("app-root")
     /**
-     * Accepts all options of https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-aichat--docs,\
-     * plus root element
+     * Accepts options of https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-ai-remoteaichatdrawer--docs
      */
     remoteAiChatDrawer.init({
       messageOrigin: "http://localhost:3000",

--- a/bundle-preview/iframe.html
+++ b/bundle-preview/iframe.html
@@ -7,6 +7,12 @@
 
   <body>
     <button id="#chat-trigger">Open Drawer</button>
+    <div>
+      <label>
+        Extra data sent to drawer:
+        <input type="text" id="extra" placeholder="Extra" />
+      </label>
+    </div>
   </body>
   <script>
     const INITIAL_MESSAGES = [
@@ -36,9 +42,13 @@
         type: "smoot-design::chat-open",
         payload: {
           askTimTitle: `for help with problems!`,
-          apiUrl: "http://ai.open.odl.local:8002/http/recommendation_agent/",
+          apiUrl:
+            "https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/",
           initialMessages: INITIAL_MESSAGES,
           conversationStarters: STARTERS,
+          requestBody: {
+            extra: document.getElementById("extra").value,
+          },
         },
       })
     })

--- a/bundle-preview/iframe.html
+++ b/bundle-preview/iframe.html
@@ -43,6 +43,8 @@
         payload: {
           askTimTitle: `for help with problems!`,
           apiUrl:
+            // Note: This will work locally, but same-site cookies used for
+            // thread identification may not work
             "https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/",
           initialMessages: INITIAL_MESSAGES,
           conversationStarters: STARTERS,

--- a/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
+++ b/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
@@ -27,7 +27,8 @@ type AiChatDrawerProps = {
   messageOrigin: string
   /**
    * Transform the body of the request before sending it to the server.
-   * Its result will be merged with the per-message requestBody opt.
+   * Its result will be merged with the per-message requestBody opt, with
+   * transformBody taking precedence.
    *
    * *This cannot be supplied via message events since the function is not serializable.*
    *
@@ -59,7 +60,6 @@ const AiChatDrawer: React.FC<AiChatDrawerProps> = ({
         setChatSettings(event.data.payload)
       }
     }
-    console.log("Attaching listener")
     window.addEventListener("message", cb)
     return () => {
       window.removeEventListener("message", cb)
@@ -89,8 +89,8 @@ const AiChatDrawer: React.FC<AiChatDrawerProps> = ({
           requestOpts={{
             transformBody: (messages) => {
               return {
-                ...transformBody?.(messages),
                 ...chatSettings.requestBody,
+                ...transformBody?.(messages),
               }
             },
             apiUrl: chatSettings?.apiUrl,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6843

### Description (What does it do?)
This PR adds a `requestBody` to the `remoteAiChatDrawer` message events, as used in https://github.com/mitodl/open-edx-plugins/pull/447


### How can this be tested?
1. Run `yarn bundle-preview`.
2. Visit http://localhost:3000/bundle-demo
3. Enter something into the input field and click "Open Drawer"
4. Send a message to the AI while looking at network tab of browser dev tools.
5. Observe the extra data sent in request body is the input tab value, set via `requestBody` in `bundle-preview/iframe.html`

