### PR TITLE
feat: Prop to provide a scroll element

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -231,6 +231,7 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
   onClose,
   ImgComponent,
   placeholder = "",
+  scrollContainer,
   ref,
   ...others // Could contain data attributes
 }) {
@@ -274,9 +275,10 @@ const AiChatInternal: React.FC<AiChatProps> = function AiChat({
   const stoppable = isLoading && messages[messages.length - 1]?.role !== "user"
 
   const scrollToBottom = () => {
-    messagesRef.current?.scrollBy({
+    const element = scrollContainer || messagesRef.current
+    element?.scrollBy({
       behavior: "instant",
-      top: messagesRef.current.scrollHeight,
+      top: element?.scrollHeight,
     })
   }
 

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -70,6 +70,12 @@ type AiChatProps = {
   ImgComponent?: React.ElementType
 
   /**
+   * Where the scroll container is provided by the component,
+   * the AiChat will scroll to the bottom when a prompt is submitted.
+   */
+  scrollContainer?: HTMLElement
+
+  /**
    * Provide a ref to the chat component to access the `append` method.
    */
   ref?: React.Ref<{


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/6815

### Description (What does it do?)
<!--- Describe your changes in detail -->

In certain contexts the scrolling and snap behavior will be handled by a parent component and not the messages container. One option is to provide an `onMessageSubmit` callback; this option just provides a prop to pass the scroll container element.
