### PR TITLE
feat: include credentials by default in remoteAiChatDrawer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude: ".hbs$"
+        exclude: ".hbs$|.html"
       - id: check-yaml
       - id: check-added-large-files
         exclude: "yarn.lock|.yarn/releases/.*|frontends/.yarn/releases/.*"

--- a/bundle-preview/bundle-demo.html
+++ b/bundle-preview/bundle-demo.html
@@ -5,22 +5,23 @@
     <title>Home</title>
     <script src="./static/bundles/remoteAiChatDrawer.umd.js"></script>
     <style>
-      #app-root {
-        width: 450px;
-        height: 600px;
+      .app-frame {
+        width: 600px;
+        max-width: 50vw;
+        height: 400px;
       }
     </style>
   </head>
 
   <body>
-    <iframe src="./iframe.html"></iframe>
+    <iframe class="app-frame" src="./iframe.html"></iframe>
   </body>
   <script>
     /**
      * Accepts options of https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-ai-remoteaichatdrawer--docs
      */
     remoteAiChatDrawer.init({
-      messageOrigin: "http://localhost:3000",
+      messageOrigin: window.location.origin, // iframe is served in same origin for this demo,
       transformBody: (messages) => ({
         message: messages[messages.length - 1].content,
       }),

--- a/bundle-preview/iframe.html
+++ b/bundle-preview/iframe.html
@@ -3,16 +3,41 @@
   <head>
     <meta charset="utf-8" />
     <title>Iframe</title>
+    <style>
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .form-field {
+        display: block;
+      }
+
+      .form-field > textarea,
+      .form-field > input {
+        width: 100%;
+        display: block;
+      }
+    </style>
   </head>
 
   <body>
-    <button id="#chat-trigger">Open Drawer</button>
-    <div>
-      <label>
+    <form class="form" id="chat-form">
+      <button>Open Drawer</button>
+      <label class="form-field">
         Extra data sent to drawer:
-        <input type="text" id="extra" placeholder="Extra" />
+        <input type="text" name="extra" id="extra" placeholder="Extra" />
       </label>
-    </div>
+
+      <label class="form-field">
+        API URL
+        <textarea id="api-url" name="apiUrl" rows="3">
+https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
+      </textarea
+        >
+      </label>
+    </form>
   </body>
   <script>
     const INITIAL_MESSAGES = [
@@ -28,28 +53,23 @@
       { content: "I am curious about AI applications for business" },
     ]
 
-    const REQUEST_OPTS = {
-      apiUrl: "http://ai.open.odl.local:8002/http/recommendation_agent/",
-      transformBody(messages) {
-        const message = messages[messages.length - 1].content
-        return { message }
-      },
-    }
-
-    const button = document.getElementById("#chat-trigger")
-    button.addEventListener("click", () => {
+    const form = document.getElementById("chat-form")
+    form.addEventListener("submit", (e) => {
+      e.preventDefault()
+      const formData = new FormData(form)
+      const data = Object.fromEntries(formData.entries())
       window.parent.postMessage({
         type: "smoot-design::chat-open",
         payload: {
           askTimTitle: `for help with problems!`,
-          apiUrl:
-            // Note: This will work locally, but same-site cookies used for
-            // thread identification may not work
-            "https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/",
+          // Get this from user input to allow
+          //  - default: https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
+          //  - other (e.g., local): http://ai.open.odl.local:8005/http/recommendation_agent
+          apiUrl: data.apiUrl.trim(),
           initialMessages: INITIAL_MESSAGES,
           conversationStarters: STARTERS,
           requestBody: {
-            extra: document.getElementById("extra").value,
+            extra: data.extra,
           },
         },
       })

--- a/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
+++ b/src/bundles/RemoteAiChatDrawer/RemoteAiChatDrawer.tsx
@@ -34,12 +34,24 @@ type AiChatDrawerProps = {
    *
    */
   transformBody?: (messages: AiChatMessage[]) => Iterable<unknown>
+  /**
+   * Fetch options to be passed to the fetch call.
+   *
+   * NOTE: By default, the credentials are set to "include" to enable thread-
+   * identifying cookies.
+   */
+  fetchOpts?: AiChatProps["requestOpts"]["fetchOpts"]
+}
+
+const DEFAULT_FETCH_OPTS: AiChatDrawerProps["fetchOpts"] = {
+  credentials: "include",
 }
 
 const AiChatDrawer: React.FC<AiChatDrawerProps> = ({
   messageOrigin,
   transformBody = identity,
   className,
+  fetchOpts,
 }: AiChatDrawerProps) => {
   const [open, setOpen] = React.useState(false)
   const [chatSettings, setChatSettings] = React.useState<
@@ -94,6 +106,7 @@ const AiChatDrawer: React.FC<AiChatDrawerProps> = ({
               }
             },
             apiUrl: chatSettings?.apiUrl,
+            fetchOpts: { ...DEFAULT_FETCH_OPTS, ...fetchOpts },
           }}
           onClose={() => setOpen(false)}
         />


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6855

### Description (What does it do?)
This PR makes the openedx chat drawer—`remoteAiChatDrawer`—include credentials (cookies) in its fetch requests by default. This is for maintaining conversation state between requests.

### How can this be tested?
1. **Easy Option:** Run `yarn bundle-preview` and visit the bundle preview at http://localhost:3000/bundle-demo Then:
    - Open the chat drawer
    - make some chat requests.
    - Inspect your local cookies (or network requests) and see that the API requests tried to set some cookies but they were rejected because localhost:3000 and api-learn-ai-qa.ol.mit.edu are not the same site. (SameSite cookies won't work).
    - But at least you saw they were trying to set the cookies. It will work on RC, since `mitxonline.mit.edu` and api-learn-ai-qa.ol.mit.edu` are the same site (.mit.edu).

2. Or, run `learn-ai` locally and visit the bundle-preview at any origin you've added a redirect for in etc host. For example:
    ```
    # api url
    http://ai.open.odl.local:8005/http/recommendation_agent/
    # visit bundle preview at
    whatever.odl.local:3000/bundle-demo
    ```
    - Then you can chat with the AI and ask it questions like "What was the last message I sent to you" and you should see it remembers (because the cookies are being set to identify your thread.)

