### PR TITLE
fix: use relative path for msw

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,18 @@ import { initialize, mswLoader } from "msw-storybook-addon"
 const ALLOW_UNHANDLED_REQUESTS = [/use\.typekit/]
 // Initialize MSW
 initialize({
+  serviceWorker: {
+    /**
+     * The default service worker location is `/mockServiceWorker.js`.,
+     * i.e., located at root.
+     *
+     * This doesn't work well for hosting in a subdirectory, e.g., github pages.
+     *
+     * Using a relative URL works fine since storybook is a SPA
+     * with msw adjacent to the index file.
+     */
+    url: "mockServiceWorker.js",
+  },
   onUnhandledRequest(request, print) {
     if (ALLOW_UNHANDLED_REQUESTS.some((regex) => regex.test(request.url))) {
       return


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR fixes the deployed storybook github pages, which is currently broken. See https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-button--docs

### How can this be tested?
1. If you want to see it broken locally, run `rm -rf deployed && mkdir -p deployed && yarn build-storybook && mv storybook-static deployed/subpath` on main branch and visit http://localhost:3000/subpath/?path=/docs/smoot-design-button--docs
2. Repeat on this branch.

