### PR TITLE
feat: Title for tutor drawer

### DIFF
--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
+import invariant from "tiny-invariant"
 import { http, HttpResponse } from "msw"
+import { handlers } from "../../components/AiChat/test-utils/api"
 import {
   RemoteTutorDrawer,
   RemoteTutorDrawerInitMessage,
 } from "./RemoteTutorDrawer"
-import invariant from "tiny-invariant"
 
 type InitPayload = RemoteTutorDrawerInitMessage["payload"]
 
@@ -33,7 +34,7 @@ const buildIFrame = (payload: InitPayload) => (el: HTMLIFrameElement) => {
   invariant(doc && parent)
   const button = doc.createElement("button")
 
-  button.textContent = "Trigger chat (Send message to parent)"
+  button.textContent = "Open drawer (send message to parent)"
   doc.body.appendChild(button)
 
   const div = doc.createElement("div")
@@ -79,7 +80,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
           payload={{
             blockType,
             target,
-            title: "AskTIM to recommend a course",
+            title: "AskTIM for help with Problem: Derivatives 1.1",
             chat: {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
@@ -140,6 +141,7 @@ export const VideoStory: Story = {
             flashcards: mockFlashcards,
           })
         }),
+        ...handlers,
       ],
     },
   },

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -79,8 +79,8 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
           payload={{
             blockType,
             target,
+            title: "AskTIM to recommend a course",
             chat: {
-              askTimTitle: "for help with Problem: Derivatives 1.1",
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
               conversationStarters: STARTERS,
@@ -93,6 +93,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
           payload={{
             blockType,
             target,
+            title: "AskTIM about this video",
             chat: {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
@@ -142,28 +143,6 @@ export const VideoStory: Story = {
       ],
     },
   },
-  render: ({ target }, { parameters: { blockType } }) => (
-    <>
-      <IFrame
-        payload={{
-          blockType,
-          target,
-          chat: {
-            apiUrl: TEST_API_STREAMING,
-            initialMessages: INITIAL_MESSAGES,
-            conversationStarters: STARTERS,
-          },
-          summary: {
-            apiUrl: CONTENT_FILE_URL,
-          },
-        }}
-      />
-      <RemoteTutorDrawer
-        target={target}
-        messageOrigin="http://localhost:6006"
-      />
-    </>
-  ),
 }
 
 // From https://api.rc.learn.mit.edu/api/v1/contentfiles/16453238/

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useState, useRef } from "react"
 import styled from "@emotion/styled"
 import Markdown from "react-markdown"
 import rehypeRaw from "rehype-raw"
-import { RiCloseLine } from "@remixicon/react"
+import { RiCloseLine, RiSparkling2Line } from "@remixicon/react"
 import Drawer from "@mui/material/Drawer"
 import {
   TabButtonList,
@@ -24,9 +24,12 @@ type RemoteTutorDrawerInitMessage = {
   payload: {
     blockType?: "problem" | "video"
     target?: string
+    /**
+     * If the title begins "AskTIM", it is styled as the AskTIM logo.
+     */
+    title?: string
     chat: {
       chatId?: AiChatProps["chatId"]
-      askTimTitle?: AiChatProps["askTimTitle"]
       conversationStarters?: AiChatProps["conversationStarters"]
       initialMessages: AiChatProps["initialMessages"]
       apiUrl: AiChatProps["requestOpts"]["apiUrl"]
@@ -38,23 +41,58 @@ type RemoteTutorDrawerInitMessage = {
   }
 }
 
+const Header = styled.div<{ externalScroll?: boolean }>(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "4px",
+  color: theme.custom.colors.white,
+  position: "sticky",
+  top: 0,
+  padding: "32px 0 16px 0",
+  zIndex: 2,
+  backgroundColor: theme.custom.colors.white,
+  borderRadius: 0,
+}))
+
+const Title = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  color: theme.custom.colors.darkGray2,
+  img: {
+    width: "24px",
+    height: "24px",
+  },
+  svg: {
+    fill: theme.custom.colors.red,
+    width: "24px",
+    height: "24px",
+    flexShrink: 0,
+  },
+  overflow: "hidden",
+  p: {
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+  },
+}))
+
 const CloseButton = styled(ActionButton)(({ theme }) => ({
-  position: "fixed",
-  top: "24px",
-  right: "40px",
   backgroundColor: theme.custom.colors.lightGray2,
   "&&:hover": {
     backgroundColor: theme.custom.colors.red,
     color: theme.custom.colors.white,
   },
   zIndex: 3,
+  flexShrink: 0,
 }))
 
 const StyledTabButtonList = styled(TabButtonList)(({ theme }) => ({
-  padding: "80px 0 16px",
+  padding: "0 0 16px",
   backgroundColor: theme.custom.colors.white,
   position: "sticky",
-  top: 0,
+  top: "84px",
   zIndex: 2,
   overflow: "visible",
 }))
@@ -69,8 +107,8 @@ const StyledAiChat = styled(AiChat)(({ hasTabs }: { hasTabs: boolean }) => ({
   ".MitAiChat--chatScreenContainer": {
     padding: hasTabs ? 0 : "0 25px 0 40px",
   },
-  ".MitAiChat--title": {
-    paddingTop: "32px",
+  ".MitAiChat--messagesContainer": {
+    paddingTop: hasTabs ? 0 : "88px",
   },
 }))
 
@@ -204,7 +242,6 @@ const ChatComponent = ({
   return (
     <StyledAiChat
       chatId={payload.chatId}
-      askTimTitle={payload.askTimTitle}
       conversationStarters={payload.conversationStarters}
       initialMessages={payload.initialMessages}
       entryScreenEnabled={false}
@@ -308,14 +345,29 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
       open={open}
       onClose={() => setOpen(false)}
     >
-      <CloseButton
-        variant="text"
-        size="medium"
-        onClick={() => setOpen(false)}
-        aria-label="Close"
-      >
-        <RiCloseLine />
-      </CloseButton>
+      <Header>
+        <Title>
+          <RiSparkling2Line />
+          <Typography variant="body1">
+            {payload.title?.includes("AskTIM") ? (
+              <>
+                Ask<strong>TIM</strong>
+                {payload.title.replace("AskTIM", "")}
+              </>
+            ) : (
+              payload.title
+            )}
+          </Typography>
+        </Title>
+        <CloseButton
+          variant="text"
+          size="medium"
+          onClick={() => setOpen(false)}
+          aria-label="Close"
+        >
+          <RiCloseLine />
+        </CloseButton>
+      </Header>
       {blockType === "problem" ? (
         <ChatComponent
           payload={chat}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/6985

### Description (What does it do?)
<!--- Describe your changes in detail -->

We were not able to set a title for the RemoteTutorDrawer and were using the AiChat component's title for the drawer title. This worked fine before we added tabs, though we can't sensibly reuse the AiChat title across tabs.

This change provides `title` on the `postMessage()` payload for opening the drawer.

Titles starting with "AskTIM" are given the <img width="59" alt="image" src="https://github.com/user-attachments/assets/4df23af8-a06a-4af2-b4aa-f778e9751300" /> treatment.

### Screenshots (if appropriate):

<img width="893" alt="image" src="https://github.com/user-attachments/assets/7fc348df-2c83-4589-85b0-eab7e8d11670" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Start Storybook with `yarn start` and navigate to http://localhost:6006/?path=/docs/smoot-design-ai-remotetutordrawer--docs. Hi the open drawer buttons and confirm the titles display as expected and layout is preserved, with attention to long chat threads.


