### PR TITLE
fix: don't crash if flashcard array is empty

### DIFF
--- a/src/bundles/RemoteTutorDrawer/FlashcardsScreen.tsx
+++ b/src/bundles/RemoteTutorDrawer/FlashcardsScreen.tsx
@@ -111,7 +111,7 @@ export const FlashcardsScreen = ({
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [handleKeyDown])
 
-  if (!flashcards) {
+  if (!flashcards || flashcards.length === 0) {
     return null
   }
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Currently if the flashcard array is empty and you click the flashcard tab, the drawer crashes and becomes unopenable. This change prevents the drawer from crashing.

### How can this be tested?
1. Run `yarn start` and visit http://localhost:6006/?path=/docs/smoot-design-ai-remotetutordrawer--docs
2. Edit the storybook file to return an empty array of flashcards 
3. open the video drawer. Click flashcard tab. It should be empty instead of crashing.

### Additional Context
☝️ May not be the most desirable behavior (e.g., we could not show the tab at all if flashcard array is empty). But this at least prevents the crashing behavior for now.

I'm going to open a separate issue to add tested (beside storybook) for this component.

- https://github.com/mitodl/hq/issues/7009