### PR TITLE
fix: Remove the flashcards tab if none

### DIFF
--- a/src/bundles/RemoteTutorDrawer/FlashcardsScreen.tsx
+++ b/src/bundles/RemoteTutorDrawer/FlashcardsScreen.tsx
@@ -111,7 +111,7 @@ export const FlashcardsScreen = ({
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [handleKeyDown])
 
-  if (!flashcards) {
+  if (!flashcards?.length) {
     return null
   }
 

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -373,12 +373,14 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
             onChange={(_event, val) => setTab(val)}
           >
             <TabButton value="chat" label="Chat" />
-            <TabButton
-              value="flashcards"
-              label="Flashcards"
-              onMouseDown={handleMouseDown}
-              onFocus={handleFocus}
-            />
+            {response?.flashcards?.length ? (
+              <TabButton
+                value="flashcards"
+                label="Flashcards"
+                onMouseDown={handleMouseDown}
+                onFocus={handleFocus}
+              />
+            ) : null}
             <TabButton value="summary" label="Summary" />
           </StyledTabButtonList>
           <StyledTabPanel value="chat">
@@ -390,12 +392,14 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
               hasTabs={hasTabs}
             />
           </StyledTabPanel>
-          <StyledTabPanel value="flashcards">
-            <FlashcardsScreen
-              flashcards={response?.flashcards}
-              wasKeyboardFocus={_wasKeyboardFocus}
-            />
-          </StyledTabPanel>
+          {response?.flashcards?.length ? (
+            <StyledTabPanel value="flashcards">
+              <FlashcardsScreen
+                flashcards={response?.flashcards}
+                wasKeyboardFocus={_wasKeyboardFocus}
+              />
+            </StyledTabPanel>
+          ) : null}
           <StyledTabPanel value="summary">
             <Typography variant="h4" component="h4"></Typography>
             <StyledHTML>


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->



Following https://github.com/mitodl/smoot-design/pull/75, removes the flashcards tab if none are returned from the API, averting the subsequent bug trying to display them.


### How can this be tested?
1. Run `yarn start` and visit http://localhost:6006/?path=/docs/smoot-design-ai-remotetutordrawer--docs
2. Edit the storybook file to return an empty array of flashcards 
3. Open the video drawer and check that the flashcard tab is not present.
