### PR TITLE
feat: Chat entry screen for the Tutor drawer

### DIFF
--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -86,7 +86,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
               conversationStarters: STARTERS,
-              ...chat
+              ...chat,
             },
           }}
         />
@@ -100,7 +100,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
               conversationStarters: STARTERS,
-              ...chat
+              ...chat,
             },
             summary: {
               apiUrl: CONTENT_FILE_URL,

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -171,7 +171,7 @@ export const VideoStory: Story = {
 }
 
 /**
- * Where conversation starters are not provided, they will be selected at randomfrom the returned flashcard questions
+ * Where conversation starters are not provided, they will be selected at random from the returned flashcard questions
  * or from `DEFAULT_VIDEO_STARTERS` provided.
  */
 export const FlashcardConversationStartersStory: Story = {

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -96,7 +96,6 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
           payload={{
             blockType,
             target,
-            title: "AskTIM about this video",
             chat: {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -74,7 +74,7 @@ const IFrame = ({ payload }: { payload: InitPayload }) => {
 
 const meta: Meta<typeof RemoteTutorDrawer> = {
   title: "smoot-design/AI/RemoteTutorDrawer",
-  render: ({ target }, { parameters: { blockType } }) => (
+  render: ({ target }, { parameters: { blockType, chat } }) => (
     <>
       {blockType === "problem" ? (
         <IFrame
@@ -100,6 +100,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
               conversationStarters: STARTERS,
+              ...chat
             },
             summary: {
               apiUrl: CONTENT_FILE_URL,
@@ -125,15 +126,49 @@ export const ProblemStory: Story = {
   },
   parameters: {
     blockType: "problem",
+    chat: {
+      conversationStarters: STARTERS,
+    },
   },
 }
 
+/**
+ * The chat entry screen is shown by default for the video blocks Tutor drawer.
+ */
 export const VideoStory: Story = {
   args: {
     target: "video-frame",
   },
   parameters: {
     blockType: "video",
+    chat: {
+      conversationStarters: STARTERS,
+    },
+    msw: {
+      handlers: [
+        http.get(CONTENT_FILE_URL, () => {
+          return HttpResponse.json(sampleResponse)
+        }),
+        ...handlers,
+      ],
+    },
+  },
+}
+
+/**
+ * Where conversation starters are not provided, they will be selected at randomfrom the returned flashcard questions
+ * or from `DEFAULT_VIDEO_STARTERS` provided.
+ */
+export const FlashcardConversationStartersStory: Story = {
+  args: {
+    target: "starters-frame",
+  },
+  parameters: {
+    blockType: "video",
+    chat: {
+      conversationStarters: undefined,
+      initialMessages: undefined,
+    },
     msw: {
       handlers: [
         http.get(CONTENT_FILE_URL, () => {

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -86,6 +86,7 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
               apiUrl: TEST_API_STREAMING,
               initialMessages: INITIAL_MESSAGES,
               conversationStarters: STARTERS,
+              ...chat
             },
           }}
         />
@@ -128,6 +129,20 @@ export const ProblemStory: Story = {
     blockType: "problem",
     chat: {
       conversationStarters: STARTERS,
+    },
+  },
+}
+
+export const EntryScreenStory: Story = {
+  args: {
+    target: "entry-screen-frame",
+  },
+  parameters: {
+    blockType: "problem",
+    chat: {
+      conversationStarters: STARTERS,
+      entryScreenEnabled: true,
+      entryScreenTitle: "AskTIM about this problem",
     },
   },
 }

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -94,7 +94,7 @@ const StyledTabButtonList = styled(TabButtonList)(({ theme }) => ({
   padding: "0 0 16px",
   backgroundColor: theme.custom.colors.white,
   position: "sticky",
-  top: "84px",
+  top: "88px",
   zIndex: 2,
   overflow: "visible",
 }))
@@ -116,7 +116,7 @@ const StyledAiChat = styled(AiChat)<{ hasTabs: boolean }>(({ hasTabs, theme }) =
     },
   },
   ".MitAiChat--messagesContainer": {
-    paddingTop: hasTabs ? 0 : "88px",
+    paddingTop: hasTabs ? "8px" : "88px",
   },
 }))
 
@@ -406,7 +406,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
         />
       ) : null}
       {blockType === "video" ? (
-        <TabContext value={tab}>
+        <TabContext value={tab} >
           <StyledTabButtonList
             styleVariant="chat"
             onChange={(_event, val) => setTab(val)}
@@ -422,7 +422,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
             ) : null}
             <TabButton value="summary" label="Summary" />
           </StyledTabButtonList>
-          <StyledTabPanel value="chat">
+          <StyledTabPanel value="chat" keepMounted>
             <ChatComponent
               payload={{
                 ...chat,

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -105,23 +105,25 @@ const StyledTabPanel = styled(TabPanel)({
   position: "relative",
 })
 
-const StyledAiChat = styled(AiChat)<{ hasTabs: boolean }>(({ hasTabs, theme }) => ({
-  ".MitAiChat--entryScreenContainer": {
-    padding: hasTabs ?  "114px 0 24px" : "168px 32px 24px",
-    [theme.breakpoints.down("md")]: {
-      padding: hasTabs ? "114px 0 24px" : "168px 16px 24px",
+const StyledAiChat = styled(AiChat)<{ hasTabs: boolean }>(
+  ({ hasTabs, theme }) => ({
+    ".MitAiChat--entryScreenContainer": {
+      padding: hasTabs ? "114px 0 24px" : "168px 32px 24px",
+      [theme.breakpoints.down("md")]: {
+        padding: hasTabs ? "114px 0 24px" : "168px 16px 24px",
+      },
     },
-  },
-  ".MitAiChat--chatScreenContainer": {
-    padding: hasTabs ? 0 : "0 32px",
-    [theme.breakpoints.down("md")]: {
-      padding: hasTabs ? 0 : "0 16px",
+    ".MitAiChat--chatScreenContainer": {
+      padding: hasTabs ? 0 : "0 32px",
+      [theme.breakpoints.down("md")]: {
+        padding: hasTabs ? 0 : "0 16px",
+      },
     },
-  },
-  ".MitAiChat--messagesContainer": {
-    paddingTop: hasTabs ? "8px" : "88px",
-  },
-}))
+    ".MitAiChat--messagesContainer": {
+      paddingTop: hasTabs ? "8px" : "88px",
+    },
+  }),
+)
 
 const StyledHTML = styled.div(({ theme }) => ({
   color: theme.custom.colors.darkGray2,
@@ -224,11 +226,15 @@ const useContentFetch = (contentUrl: string | undefined) => {
   return { response, loading }
 }
 
-const DEFAULT_VIDEO_ENTRY_SCREEN_TITLE = "What do you want to know about this video?"
+const DEFAULT_VIDEO_ENTRY_SCREEN_TITLE =
+  "What do you want to know about this video?"
 
 const DEFAULT_VIDEO_STARTERS = [
   { content: "What are the most important concepts introduced in the video?" },
-  { content: "What examples are used to illustrate concepts covered in the video?" },
+  {
+    content:
+      "What examples are used to illustrate concepts covered in the video?",
+  },
   { content: "What are the key terms introduced in this video?" },
 ]
 
@@ -252,7 +258,7 @@ const ChatComponent = ({
   hasTabs: boolean
 }) => {
   if (!payload) return null
-console.log('entryScreenEnabled', entryScreenEnabled)
+  console.log("entryScreenEnabled", entryScreenEnabled)
   return (
     <StyledAiChat
       chatId={payload.chatId}
@@ -343,11 +349,15 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
 
   const conversationStarters = useMemo(() => {
     if (!payload) return []
-    return payload.chat.conversationStarters ||
-      (response?.flashcards ? randomItems(response.flashcards, 3).map((flashcard) => ({ content: flashcard.question })) : DEFAULT_VIDEO_STARTERS)
-    },
-    [payload, response]
-  )
+    return (
+      payload.chat.conversationStarters ||
+      (response?.flashcards
+        ? randomItems(response.flashcards, 3).map((flashcard) => ({
+            content: flashcard.question,
+          }))
+        : DEFAULT_VIDEO_STARTERS)
+    )
+  }, [payload, response])
 
   if (!payload) {
     return null
@@ -367,8 +377,8 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
           boxSizing: "border-box",
           padding: {
             xs: "0 16px",
-            md: "0 32px"
-          }
+            md: "0 32px",
+          },
         },
       }}
       anchor="right"
@@ -410,7 +420,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
         />
       ) : null}
       {blockType === "video" ? (
-        <TabContext value={tab} >
+        <TabContext value={tab}>
           <StyledTabButtonList
             styleVariant="chat"
             onChange={(_event, val) => setTab(val)}
@@ -435,7 +445,10 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
               fetchOpts={fetchOpts}
               scrollElement={scrollElement}
               entryScreenEnabled={payload.chat?.entryScreenEnabled ?? true}
-              entryScreenTitle={payload.chat.entryScreenTitle ?? DEFAULT_VIDEO_ENTRY_SCREEN_TITLE}
+              entryScreenTitle={
+                payload.chat.entryScreenTitle ??
+                DEFAULT_VIDEO_ENTRY_SCREEN_TITLE
+              }
               conversationStarters={conversationStarters}
               hasTabs={hasTabs}
             />

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -258,7 +258,6 @@ const ChatComponent = ({
   hasTabs: boolean
 }) => {
   if (!payload) return null
-  console.log("entryScreenEnabled", entryScreenEnabled)
   return (
     <StyledAiChat
       chatId={payload.chatId}

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -346,6 +346,12 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
     }
   }, [messageOrigin, target])
 
+  useEffect(() => {
+    scrollElement?.scrollTo({
+      top: tab === "chat" ? scrollElement.scrollHeight : 0,
+    })
+  }, [tab, scrollElement])
+
   const conversationStarters = useMemo(() => {
     if (!payload) return []
     return (
@@ -422,7 +428,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
         <TabContext value={tab}>
           <StyledTabButtonList
             styleVariant="chat"
-            onChange={(_event, val) => setTab(val)}
+            onChange={(e, tab) => setTab(tab)}
           >
             <TabButton value="chat" label="Chat" />
             {response?.flashcards?.length ? (

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -107,12 +107,15 @@ const StyledTabPanel = styled(TabPanel)({
 
 const StyledAiChat = styled(AiChat)<{ hasTabs: boolean }>(({ hasTabs, theme }) => ({
   ".MitAiChat--entryScreenContainer": {
-    padding: "114px 0 24px",
+    padding: hasTabs ?  "114px 0 24px" : "168px 32px 24px",
+    [theme.breakpoints.down("md")]: {
+      padding: hasTabs ? "114px 0 24px" : "168px 16px 24px",
+    },
   },
   ".MitAiChat--chatScreenContainer": {
     padding: hasTabs ? 0 : "0 32px",
     [theme.breakpoints.down("md")]: {
-      padding: hasTabs ? 0 :"0 16px",
+      padding: hasTabs ? 0 : "0 16px",
     },
   },
   ".MitAiChat--messagesContainer": {
@@ -221,7 +224,7 @@ const useContentFetch = (contentUrl: string | undefined) => {
   return { response, loading }
 }
 
-const DEFAULT_ENTRY_SCREEN_TITLE = "What do you want to know about this video?"
+const DEFAULT_VIDEO_ENTRY_SCREEN_TITLE = "What do you want to know about this video?"
 
 const DEFAULT_VIDEO_STARTERS = [
   { content: "What are the most important concepts introduced in the video?" },
@@ -249,7 +252,7 @@ const ChatComponent = ({
   hasTabs: boolean
 }) => {
   if (!payload) return null
-
+console.log('entryScreenEnabled', entryScreenEnabled)
   return (
     <StyledAiChat
       chatId={payload.chatId}
@@ -401,7 +404,8 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
           transformBody={transformBody}
           fetchOpts={fetchOpts}
           scrollElement={scrollElement}
-          entryScreenEnabled={false}
+          entryScreenEnabled={payload.chat?.entryScreenEnabled ?? false}
+          entryScreenTitle={payload.chat.entryScreenTitle}
           hasTabs={hasTabs}
         />
       ) : null}
@@ -430,8 +434,8 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
               transformBody={transformBody}
               fetchOpts={fetchOpts}
               scrollElement={scrollElement}
-              entryScreenEnabled={true}
-              entryScreenTitle={payload.chat.entryScreenTitle ?? DEFAULT_ENTRY_SCREEN_TITLE}
+              entryScreenEnabled={payload.chat?.entryScreenEnabled ?? true}
+              entryScreenTitle={payload.chat.entryScreenTitle ?? DEFAULT_VIDEO_ENTRY_SCREEN_TITLE}
               conversationStarters={conversationStarters}
               hasTabs={hasTabs}
             />

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -377,7 +377,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
     >
       <Header>
         <Title>
-          <RiSparkling2Line />
+          {payload.title ? <RiSparkling2Line /> : null}
           <Typography variant="body1">
             {payload.title?.includes("AskTIM") ? (
               <>

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -36,7 +36,7 @@ const Container = styled.div()
 
 const ChatScreen = styled.div<{ externalScroll: boolean }>(
   ({ externalScroll, theme }) => ({
-    padding: "16px 28px 0",
+    padding: "16px 32px 0",
     [theme.breakpoints.down("md")]: {
       padding: "16px 16px 0",
     },
@@ -49,7 +49,7 @@ const ChatScreen = styled.div<{ externalScroll: boolean }>(
     right: 0,
     zIndex: 1,
     ...(externalScroll && {
-      padding: "0 28px",
+      padding: "0 32px",
       [theme.breakpoints.down("md")]: {
         padding: "0 16px",
       },
@@ -280,16 +280,6 @@ const AiChat: FC<AiChatProps> = ({
               return
             }
             setShowEntryScreen(false)
-            if (entryScreenTitle && !initialMessages) {
-              setInitialMessages([
-                {
-                  role: "assistant",
-                  content: entryScreenTitle,
-                  id: `initial-${Math.random().toString().slice(2)}-0`,
-                },
-              ])
-            }
-
             append({ role: "user", content: prompt })
           }}
         />

--- a/src/components/AiChat/EntryScreen.tsx
+++ b/src/components/AiChat/EntryScreen.tsx
@@ -83,7 +83,6 @@ const Starter = styled.button(({ theme }) => ({
   backgroundColor: "transparent",
   textAlign: "left",
   [theme.breakpoints.down("sm")]: {
-    textAlign: "center",
     padding: "12px 36px",
   },
   ":hover": {


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/7010

### Description (What does it do?)
<!--- Describe your changes in detail -->

Displays the chat entry screen by default for the Tutor drawer, when opened on a video block.

- Provides the option to override the default `entryScreenEnabled`
- Selects 3 starter messages from the returned flashcard questions where none provided, or uses hardcoded defaults.
- Padding adjustments and mobile breakpoints.

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9e858335-0560-4af5-b3a7-4dfd270fcc21)

![image](https://github.com/user-attachments/assets/e650d979-8c03-44fb-8561-247ebca95549)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `yarn start` and load http://localhost:6006/?path=/docs/smoot-design-ai-remotetutordrawer--docs.

Open the drawer in the Video Story and check that layout is preserved, conversation starters are correctly set and the chat screen is preserved between tab navigation.



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Minor breaking change for release:

- The AiChat no longer uses the `entryScreenTitle` as initial assistant message by default.

Notes for upgrade on OpenEdx Plugin:

- `chat.title` should be removed for video blocks or while showing the entry screen to avoid competing titles:


<img src=https://github.com/user-attachments/assets/4fb01e68-1a6d-4353-b849-467a9ac943cb width=500 />

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
