### PR TITLE
fix: use automatic github token during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
         run: npm audit signatures
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release --dry-run

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main"],
+  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main", "cc/fix-release"],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7053

### Description (What does it do?)
Switches the semantic-release github token to the [automatic token created for github actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret) rather than the personal token tied to my account (!)

### How can this be tested?
1. View https://github.com/mitodl/smoot-design/actions/runs/14314603143/job/40117702828,  this is a run of the release action using `--dry-run` (first commit on this branch) that verifies permissions.
