### PR TITLE
feat: publish our customized tab components

### DIFF
--- a/src/components/TabButtons/TabButtonList.tsx
+++ b/src/components/TabButtons/TabButtonList.tsx
@@ -17,7 +17,7 @@ const defaultTabListProps = {
 
 type StyleVariant = "chat"
 
-export type TabButtonListProps = TabListProps & {
+type TabButtonListProps = TabListProps & {
   styleVariant?: StyleVariant
 }
 
@@ -104,12 +104,21 @@ type TabButtonProps = Omit<TabProps<"button">, "color"> & {
   styleVariant?: StyleVariant
 }
 
+/**
+ * Wrapper around [MUI Tab](https://mui.com/material-ui/api/tab/) using our
+ * Button as the `component` implementation.
+ */
 const TabButton = (props: TabButtonProps) => (
   <MuiTab {...props} component={TabButtonInner} />
 )
 
+/**
+ * Wrapper around [MUI Tab](https://mui.com/material-ui/api/tab/) using our
+ * ButtonLink as the `component` implementation.
+ */
 const TabButtonLink = ({ ...props }: TabProps<typeof TabLinkInner>) => (
   <MuiTab {...props} component={TabLinkInner} />
 )
 
 export { TabButtonList, TabButton, TabButtonLink }
+export type { TabButtonListProps, TabButtonProps }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,4 +29,11 @@ export type { TextFieldProps } from "./components/TextField/TextField"
 
 export { SrAnnouncer } from "./components/SrAnnouncer/SrAnnouncer"
 export type { SrAnnouncerProps } from "./components/SrAnnouncer/SrAnnouncer"
+
+export {
+  TabButton,
+  TabButtonLink,
+  TabButtonList,
+} from "./components/TabButtons/TabButtonList"
+
 export { VisuallyHidden } from "./components/VisuallyHidden/VisuallyHidden"


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/7090

### Description (What does it do?)
In a previous PR, we added Tab-related components https://github.com/mitodl/smoot-design/pull/67 for use inside chat. This PR publishes them.

Note: These are the same tabs used inside MIT Learn today, so the learn ones could be replaced with these now. (In https://github.com/mitodl/smoot-design/pull/67 an optional variant was added, but the default is the Learn tabs.)

### Screenshots (if appropriate):
See https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-tabbuttons--docs
