### PR TITLE
fix: Accessibility issues

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -123,10 +123,6 @@ const Message = styled.div(({ theme }) => ({
     borderRadius: "8px 0px 8px 8px",
     backgroundColor: theme.custom.colors.lightGray1,
   },
-  "&:focus-visible": {
-    outlineOffset: "-1px",
-    padding: "12px 16px",
-  },
 }))
 
 const StarterContainer = styled.div({
@@ -329,8 +325,8 @@ const AiChat: FC<AiChatProps> = ({
                     [classes.messageRowAssistant]: m.role === "assistant",
                   })}
                 >
-                  <Message className={classes.message} tabIndex={0}>
-                    <VisuallyHidden>
+                  <Message className={classes.message}>
+                    <VisuallyHidden as="h6">
                       {m.role === "user" ? "You said: " : "Assistant said: "}
                     </VisuallyHidden>
                     <Markdown skipHtml>{m.content}</Markdown>

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -194,6 +194,7 @@ const AiChat: FC<AiChatProps> = ({
   const [showEntryScreen, setShowEntryScreen] = useState(entryScreenEnabled)
   const chatScreenRef = useRef<HTMLDivElement>(null)
   const [initialMessages, setInitialMessages] = useState<AiChatMessage[]>()
+  const promptInputRef = useRef<HTMLDivElement>(null)
 
   const {
     messages: unparsed,
@@ -226,6 +227,12 @@ const AiChat: FC<AiChatProps> = ({
       )
     }
   }, [_initialMessages])
+
+  useEffect(() => {
+    if (!showEntryScreen) {
+      promptInputRef.current?.querySelector("input")?.focus()
+    }
+  }, [showEntryScreen])
 
   const messages = useMemo(() => {
     const initial = initialMessages?.map((m) => m.id)
@@ -373,6 +380,7 @@ const AiChat: FC<AiChatProps> = ({
                 }}
               >
                 <Input
+                  ref={promptInputRef}
                   fullWidth
                   size="chat"
                   className={classes.input}

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -326,7 +326,7 @@ const AiChat: FC<AiChatProps> = ({
                   })}
                 >
                   <Message className={classes.message}>
-                    <VisuallyHidden as="h6">
+                    <VisuallyHidden as={m.role === "user" ? "h5" : "h6"}>
                       {m.role === "user" ? "You said: " : "Assistant said: "}
                     </VisuallyHidden>
                     <Markdown skipHtml>{m.content}</Markdown>

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -168,6 +168,10 @@ const BottomSection = styled.div<{ externalScroll: boolean }>(
       bottom: 0,
       background: theme.custom.colors.white,
     }),
+    "button:focus-visible": {
+      outlineOffset: "-1px",
+      borderRadius: "7px",
+    },
   }),
 )
 
@@ -393,6 +397,9 @@ const AiChat: FC<AiChatProps> = ({
                   sx={{ flex: 1 }}
                   value={input}
                   onChange={handleInputChange}
+                  inputProps={{
+                    "aria-label": "Ask a question",
+                  }}
                   endAdornment={
                     isLoading ? (
                       <AdornmentButton

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -123,6 +123,10 @@ const Message = styled.div(({ theme }) => ({
     borderRadius: "8px 0px 8px 8px",
     backgroundColor: theme.custom.colors.lightGray1,
   },
+  "&:focus-visible": {
+    outlineOffset: "-1px",
+    padding: "12px 16px",
+  },
 }))
 
 const StarterContainer = styled.div({
@@ -321,7 +325,7 @@ const AiChat: FC<AiChatProps> = ({
                     [classes.messageRowAssistant]: m.role === "assistant",
                   })}
                 >
-                  <Message className={classes.message}>
+                  <Message className={classes.message} tabIndex={0}>
                     <VisuallyHidden>
                       {m.role === "user" ? "You said: " : "Assistant said: "}
                     </VisuallyHidden>

--- a/src/components/AiChat/EntryScreen.tsx
+++ b/src/components/AiChat/EntryScreen.tsx
@@ -54,6 +54,10 @@ const StyledInput = styled(Input)({
   borderRadius: "8px",
   margin: "8px 0 24px 0",
   flexShrink: 0,
+  "button:focus-visible": {
+    outlineOffset: "-1px",
+    borderRadius: "7px",
+  },
 })
 
 const SendIcon = styled(RiSendPlaneFill)(({ theme }) => ({
@@ -132,6 +136,9 @@ const EntryScreen = ({
         size="chat"
         onChange={onPromptChange}
         onKeyDown={onPromptKeyDown}
+        inputProps={{
+          "aria-label": "Ask a question",
+        }}
         endAdornment={
           <AdornmentButton
             aria-label="Send"

--- a/src/components/AiChat/EntryScreen.tsx
+++ b/src/components/AiChat/EntryScreen.tsx
@@ -147,7 +147,7 @@ const EntryScreen = ({
           <Starter
             key={index}
             onClick={() => onPromptSubmit(content)}
-            tabIndex={index}
+            tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 onPromptSubmit(content)

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -118,15 +118,6 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
       borderRadius: "8px",
       borderColor: theme.custom.colors.silverGrayLight,
       backgroundColor: theme.custom.colors.white,
-      "&:hover:not(.Mui-disabled), &.Mui-focused, :hover:not(.Mui-disabled):not(.Mui-focused)":
-        {
-          boxShadow: "0px 8px 20px 0px rgba(120, 147, 172, 0.10)",
-          borderColor: theme.custom.colors.silverGray,
-          outline: "none",
-          svg: {
-            fill: theme.custom.colors.lightRed,
-          },
-        },
       ".Mit-AdornmentButton": {
         padding: "0 16px",
       },
@@ -209,7 +200,7 @@ const noForward = Object.keys({
  * **Note:** This component is a styled version of MUI's `InputBase`. See
  * MUI's documentation for full info.
  *
- * - [Smoot Design Input Documentation](https://mitodl.github.io/smoot-design/https://mitodl.github.io/smoot-design/)
+ * - [Smoot Design Input Documentation](https://mitodl.github.io/smoot-design/?path=/docs/smoot-design-input--docs)
  * - [InputBase Documentation](https://mui.com/api/input-base/)
  */
 const Input: React.FC<InputProps> = styled(InputBase, {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

In part addresses: https://github.com/mitodl/hq/issues/7082

### Description (What does it do?)
<!--- Describe your changes in detail -->

<br />

#### Chat prompt input should receive focus after submit from entry screen (text input and starters buttons).

To test, in http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs, in the first story showing the entry screen:
- enter a prompt
- click a conversation starter button

The message input should be focused and accepting keyboard input for both cases.

<br />

#### High: Entry screen conversation starter buttons should have a natural tab order

To test, in http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs, in the first story showing the entry screen:

- Tab through the conversation starter buttons. 

They should receive tab focus in the order they appear. Hitting enter on a focused button should submit the prompt.

<br />

#### High: Entry screen prompt submit needs a label for screen readers.

To test, in http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs, in the first story showing the entry screen. Using a screen reader (cmd+F5 for VoiceOver if you're on a mac):

- Click on or tab to the entry screen prompt input.
- Click on or tab to the chat messages prompt input.

The screen reader should read "Ask a question" for both cases.

<br />

#### Entry screen prompt input should have more prominent focus styles (match blue border on starts buttons).

To test, in http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs, in the first story showing the entry screen. 

- Tab to the entry screen prompt input.
- Tab to the chat messages prompt input.

Confirm the prominent outlines are displayed on the input containers:
 
![image](https://github.com/user-attachments/assets/46eed438-c38c-4875-bfdf-485c16e67518)

![image](https://github.com/user-attachments/assets/75613abb-22f7-4fd1-91a2-f9c5d0df8e79)

Note - the black outline is used, in line with the Learn site and default Smoot Design style.

<br />

#### Add structure and mechanisms to navigate the messages thread for screen readers.

To test, in http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs in a message thread:

- Click Tab to focus messages and Shift+Tab to focus previous.

Messages should be focused in the order they appear. Keyboard focused messages should be highlighted with an outline.

![image](https://github.com/user-attachments/assets/2d61afa6-d743-45da-b7af-72acfea0189f)

![image](https://github.com/user-attachments/assets/5dee28f0-c0f8-4061-b656-e6a7abc5de2e)


