### PR TITLE
fix: Remove double indent for chat message ordered lists

### DIFF
--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -109,6 +109,14 @@ Sometimes, unordered lists are nested within ordered lists:
     - Item 2.1
     - Item 2.2
 
+Sometimes, ordered lists are nested within unordered lists:
+- Item 1
+    1. Item 1.1
+    2. Item 1.2
+- Item 2
+    1. Item 2.1
+    2. Item 2.2
+
 Here is a longer paragraph and **bold text** and *italic text*. Lorem ipsum dolor sit amet, consectetur adipiscing elit
 sed do eiusmod tempor [incididunt](https://mit.edu) ut labore et dolore magna aliqua. Ut enim ad minim veniam.
 

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -104,6 +104,10 @@ const Message = styled.div(({ theme }) => ({
   },
   "ol, ul": {
     paddingInlineStart: "16px",
+    marginLeft: "6px",
+    "ol, ul": {
+      marginLeft: 0,
+    },
     li: {
       margin: "16px 0",
     },

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -103,13 +103,10 @@ const Message = styled.div(({ theme }) => ({
     marginBottom: 0,
   },
   "ol, ul": {
-    paddingInlineStart: "32px",
+    paddingInlineStart: "16px",
     li: {
       margin: "16px 0",
     },
-  },
-  ul: {
-    marginInlineStart: "-16px",
   },
   a: {
     color: theme.custom.colors.red,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Small fix.

### Description (What does it do?)
<!--- Describe your changes in detail -->

Removes the double indentation for \<ol\> elements in chat. It was intended to accommodate longer lists with numbers that  overflow to the left, but looks incorrect where we have unordered lists nested within ordered lists.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->


![image](https://github.com/user-attachments/assets/8451d214-ad18-48bc-8b41-0b5f5800aa83)


### How can this be tested?

Run `yarn start`

There's a story with some list variations at http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs#markdown-styling-3

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
