### PR TITLE
feat: rehype mathjax

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,9 @@ const config: Config.InitialOptions = {
     "\\.(css|scss|svg|jpg|jpeg|png)$": "<rootDir>/test-utils/filemock.js",
     "^rehype-raw$": "<rootDir>/test-utils/modulemock.js",
     "^react-markdown$": "<rootDir>/test-utils/modulemock.js",
+    "^rehype-mathjax/browser$": "<rootDir>/test-utils/modulemock.js",
+    "^remark-math$": "<rootDir>/test-utils/modulemock.js",
+    "^better-react-mathjax$": "<rootDir>/test-utils/modulemock.js",
   },
   rootDir: "./src",
 }

--- a/package.json
+++ b/package.json
@@ -65,10 +65,13 @@
     "@ai-sdk/react": "1.2.11",
     "@emotion/cache": "^11.14.0",
     "@mui/utils": "^6.1.6",
+    "better-react-mathjax": "^2.3.0",
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react-markdown": "^10.0.0",
+    "rehype-mathjax": "^7.1.0",
     "rehype-raw": "^7.0.0",
+    "remark-math": "^6.0.0",
     "tiny-invariant": "^1.3.1",
     "zod": "^3.23.8"
   },

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -8,6 +8,7 @@ import {
   RemoteTutorDrawer,
   RemoteTutorDrawerInitMessage,
 } from "./RemoteTutorDrawer"
+import { MathJaxContext } from "better-react-mathjax"
 
 type InitPayload = RemoteTutorDrawerInitMessage["payload"]
 
@@ -78,10 +79,12 @@ const meta: Meta<typeof RemoteTutorDrawer> = {
   render: ({ target }, { parameters: { payload } }) => (
     <>
       <IFrame payload={payload} />
-      <RemoteTutorDrawer
-        target={target}
-        messageOrigin="http://localhost:6006"
-      />
+      <MathJaxContext>
+        <RemoteTutorDrawer
+          target={target}
+          messageOrigin="http://localhost:6006"
+        />
+      </MathJaxContext>
     </>
   ),
 }

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.test.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.test.tsx
@@ -7,7 +7,7 @@ import * as React from "react"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
-jest.mock("react-markdown", () => {
+jest.mock("../../components/AiChat/Markdown", () => {
   return {
     __esModule: true,
     default: ({ children }: { children: string }) => <div>{children}</div>,

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -256,6 +256,7 @@ const ChatComponent = ({
   conversationStarters,
   initialMessages,
   hasTabs,
+  needsMathJax,
 }: {
   payload: RemoteTutorDrawerInitMessage["payload"]["chat"]
   transformBody: (messages: AiChatMessage[]) => Iterable<unknown>
@@ -266,6 +267,7 @@ const ChatComponent = ({
   conversationStarters?: AiChatProps["conversationStarters"]
   initialMessages?: AiChatProps["initialMessages"]
   hasTabs: boolean
+  needsMathJax: boolean
 }) => {
   if (!payload) return null
   return (
@@ -285,6 +287,7 @@ const ChatComponent = ({
         fetchOpts: { ...DEFAULT_FETCH_OPTS, ...fetchOpts },
       }}
       hasTabs={hasTabs}
+      useMathJax={needsMathJax}
     />
   )
 }
@@ -380,7 +383,6 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
 
   const { blockType, chat } = payload
   const hasTabs = blockType === "video"
-
   return (
     <Drawer
       data-testid="remote-tutor-drawer"
@@ -438,6 +440,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
             payload.chat.initialMessages || DEFAULT_PROBLEM_INITIAL_MESSAGES
           }
           hasTabs={hasTabs}
+          needsMathJax={true}
         />
       ) : null}
       {blockType === "video" ? (
@@ -473,6 +476,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
               conversationStarters={conversationStarters}
               initialMessages={payload.chat.initialMessages}
               hasTabs={hasTabs}
+              needsMathJax={false}
             />
           </StyledTabPanel>
           {response?.flashcards?.length ? (

--- a/src/bundles/remoteTutorDrawer.tsx
+++ b/src/bundles/remoteTutorDrawer.tsx
@@ -8,6 +8,7 @@ import {
 } from "../components/ThemeProvider/ThemeProvider"
 import { CacheProvider } from "@emotion/react"
 import createCache from "@emotion/cache"
+import { MathJaxContext } from "better-react-mathjax"
 
 /**
  * Renders the RemoteTutorDrawer in an shadow DOM in order to isolate the drawer
@@ -38,7 +39,10 @@ const init = (opts: RemoteTutorDrawerProps) => {
   createRoot(shadowRootEl).render(
     <CacheProvider value={cache}>
       <ThemeProvider theme={theme}>
-        <RemoteTutorDrawer {...opts} />
+        <MathJaxContext>
+          <RemoteTutorDrawer {...opts} />
+        </MathJaxContext>
+        ,
       </ThemeProvider>
     </CacheProvider>,
   )

--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -5,6 +5,7 @@ import type { AiChatProps } from "./types"
 import styled from "@emotion/styled"
 import { handlers } from "./test-utils/api"
 import { FC, useEffect, useRef, useState } from "react"
+import { MathJaxContext } from "better-react-mathjax"
 
 const TEST_API_STREAMING = "http://localhost:4567/streaming"
 const TEST_API_JSON = "http://localhost:4567/json"
@@ -45,9 +46,11 @@ const meta: Meta<typeof AiChat> = {
   render: (args) => <AiChat {...args} />,
   decorators: (Story, context) => {
     return (
-      <Container>
-        <Story key={String(context.args.entryScreenEnabled)} />
-      </Container>
+      <MathJaxContext>
+        <Container>
+          <Story key={String(context.args.entryScreenEnabled)} />
+        </Container>
+      </MathJaxContext>
     )
   },
   args: {
@@ -125,6 +128,17 @@ And some inline code, \`\`<inline></inline>\`\` and code block:
 def f(x):
     print(x)
 \`\`\`
+
+And some inline  math: $x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}$
+
+And some block math:
+\n
+
+$$
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+$$
+
+Math is rendered using MathJax only if the useMathJax prop is set to true.
 `
 
 /**
@@ -141,6 +155,7 @@ export const MarkdownStyling: Story = {
         content: DEMO_MARKDOWN,
       },
     ],
+    useMathJax: true,
   },
 }
 

--- a/src/components/AiChat/Markdown.tsx
+++ b/src/components/AiChat/Markdown.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import ReactMarkdown from "react-markdown"
+import rehypeMathjax from "rehype-mathjax/browser"
+import remarkMath from "remark-math"
+import { MathJax } from "better-react-mathjax"
+
+type MarkdownProps = {
+  children?: string
+  enableMathjax?: boolean
+}
+const Markdown: React.FC<MarkdownProps> = ({ children, enableMathjax }) => {
+  const remarkPlugins = enableMathjax ? [remarkMath] : undefined
+  const rehypePlugins = enableMathjax ? [rehypeMathjax] : undefined
+
+  const markdown = (
+    <ReactMarkdown
+      skipHtml={true}
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
+    >
+      {children}
+    </ReactMarkdown>
+  )
+
+  return enableMathjax ? <MathJax>{markdown}</MathJax> : markdown
+}
+
+export default Markdown

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -6,6 +6,15 @@ const SAMPLE_RESPONSES = [
 1. **[Machine Learning, Modeling, and Simulation Principles](https://xpro.mit.edu/courses/course-v1:xPRO+MLx1/)**: Offered by MIT xPRO, this course is part of the program "Machine Learning, Modeling, and Simulation: Engineering Problem-Solving in the Age of AI." It focuses on the principles of machine learning and how they can be applied to solve engineering problems, which is highly relevant for business applications of AI.
 
 This course is not free, but it provides a certification upon completion, which can be valuable for professionals looking to apply AI in business contexts. It covers essential concepts that can help you understand how AI can be leveraged to improve business processes and decision-making.
+Here is some inline  math: $x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}$
+
+And some block math:
+\n
+
+$$
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+$$
+
 <!-- Comment! -->
 `,
   `
@@ -16,6 +25,15 @@ To understand global warming, I recommend the following resources from MIT:
 2. **[Global Warming Science](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+12.340x+1T2020/about)**: Another offering of the same course by MITx, available through the Open Learning Library. It provides the same in-depth exploration of the earth's climate system.
 
 These courses are free and provide a solid foundation in understanding the scientific aspects of global warming. They are suitable for anyone interested in the topic, regardless of prior knowledge.
+Here is some inline  math: $x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}$
+
+And some block math:
+\n
+
+$$
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+$$
+
 <!-- Comment! -->
 `,
   `
@@ -28,6 +46,16 @@ Here are some courses on linear algebra that you can explore:
 3. **[Quantum Information Science I, Part 1 (MITx)](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.370.1x+1T2018/about)**: While primarily focused on quantum information science, this course requires some knowledge of linear algebra and is suitable for those interested in quantum mechanics. It is free and available through MITx.
 
 These courses provide a comprehensive introduction to linear algebra and its applications across various fields.
+
+Here is some inline  math: $x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}$
+
+And some block math:
+\n
+
+$$
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+$$
+
 <!-- Comment! -->
 `,
   `Here are some courses on quantum computing that offer certificates:
@@ -42,7 +70,18 @@ These courses provide a comprehensive introduction to linear algebra and its app
    - **Offered by**: MIT xPRO
    - **Instructors**: Isaac Chuang, William Oliver, Peter Shor, Aram Harrow
 
-These courses are part of professional certificate programs, and you can choose to complete the entire program or take individual courses for certification.`,
+These courses are part of professional certificate programs, and you can choose to complete the entire program or take individual courses for certification.
+
+
+Here is some inline  math: $x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}$
+
+And some block math:
+\n
+
+$$
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+$$
+`,
 ]
 
 const rand = (min: number, max: number) => {

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -94,6 +94,12 @@ type AiChatDisplayProps = {
    * the AiChat will scroll to the bottom as chat messages are added.
    */
   scrollElement?: HTMLElement | null
+
+  /**
+   * If true, the chat will display math equations using MathJax.
+   * Defaults to false.
+   */
+  useMathJax?: boolean
 } & RefAttributes<HTMLDivElement>
 
 type AiChatProps = AiChatContextProps & AiChatDisplayProps

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,6 +2820,7 @@ __metadata:
     "@types/react-dom": "npm:^19.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.13.0"
     "@typescript-eslint/typescript-estree": "npm:^8.13.0"
+    better-react-mathjax: "npm:^2.3.0"
     classnames: "npm:^2.5.1"
     conventional-changelog-conventionalcommits: "npm:^8.0.0"
     eslint: "npm:8.57.1"
@@ -2847,7 +2848,9 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-markdown: "npm:^10.0.0"
+    rehype-mathjax: "npm:^7.1.0"
     rehype-raw: "npm:^7.0.0"
+    remark-math: "npm:^6.0.0"
     semantic-release: "npm:^24.2.0"
     storybook: "npm:^8.6.7"
     tiny-invariant: "npm:^1.3.1"
@@ -5110,10 +5113,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/katex@npm:^0.16.0":
+  version: 0.16.7
+  resolution: "@types/katex@npm:0.16.7"
+  checksum: 10/4fd15d93553be97c02c064e16be18d7ccbabf66ec72a9dc7fd5bfa47f0c7581da2f942f693c7cb59499de4c843c2189796e49c9647d336cbd52b777b6722a95a
+  languageName: node
+  linkType: hard
+
 "@types/lodash@npm:^4.17.13":
   version: 4.17.16
   resolution: "@types/lodash@npm:4.17.16"
   checksum: 10/9a8bb7471a7521bd65d528e1bd14f79819a3eeb6f8a35a8a44649a7d773775c0813e93fd93bd32ccf350bb076c0bf02c6d47877c4625f526f6dd4d283c746aec
+  languageName: node
+  linkType: hard
+
+"@types/mathjax@npm:^0.0.40":
+  version: 0.0.40
+  resolution: "@types/mathjax@npm:0.0.40"
+  checksum: 10/f3fa73adcf929898c22680ec3cde31ae9c6ef89842d08f4af29346f27cfa52928adc2fd62ca5a3c8f07ed55fc13edffdf03506020c7d051b15843f9f70f3ce17
   languageName: node
   linkType: hard
 
@@ -5774,6 +5791,13 @@ __metadata:
     "@webassemblyjs/ast": "npm:1.14.1"
     "@xtuc/long": "npm:4.2.2"
   checksum: 10/cef09aad2fcd291bfcf9efdae2ea1e961a1ba0f925d1d9dcdd8c746d32fbaf431b6d26a0241699c0e39f82139018aa720b4ceb84ac6f4c78f13072747480db69
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:0.9.8":
+  version: 0.9.8
+  resolution: "@xmldom/xmldom@npm:0.9.8"
+  checksum: 10/5f88d27a50bb624b0b46b8359853e1a3501217e743b132c5cbe76115646bb4b7a2128c1f0c32f045c7b452689f5206e9bba7d7292c6c13a81eed5e43c2e5ec7c
   languageName: node
   linkType: hard
 
@@ -6504,6 +6528,17 @@ __metadata:
   dependencies:
     open: "npm:^8.0.4"
   checksum: 10/24668e5a837d0d2c0edf17ad5ebcfeb00a8a5578a5eb09f7a409e1a60617cdfea40b8ebfc95e5f12d9568157930d033e6805788fcf0780413ac982c95d3745d1
+  languageName: node
+  linkType: hard
+
+"better-react-mathjax@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "better-react-mathjax@npm:2.3.0"
+  dependencies:
+    mathjax-full: "npm:^3.2.2"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 10/c8780681758c161d20d369d084eac18b8ec0317eb77bafbfe48c753fc75b718ccd6480f9edb9359223a5c16801268370be6631bc438d76db954b85398194419f
   languageName: node
   linkType: hard
 
@@ -7252,6 +7287,13 @@ __metadata:
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
   checksum: 10/e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
+  languageName: node
+  linkType: hard
+
+"commander@npm:13.1.0":
+  version: 13.1.0
+  resolution: "commander@npm:13.1.0"
+  checksum: 10/d3b4b79e6be8471ddadacbb8cd441fe82154d7da7393b50e76165a9e29ccdb74fa911a186437b9a211d0fc071db6051915c94fb8ef16d77511d898e9dbabc6af
   languageName: node
   linkType: hard
 
@@ -8878,6 +8920,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esm@npm:^3.2.25":
+  version: 3.2.25
+  resolution: "esm@npm:3.2.25"
+  checksum: 10/ee96b8202b76dd1841c55e8a066608d6f0ae0333012be5c77829ccadcd21114283b4d7bf9ac1b8c09853258829c7843e9c6d7e0594acbc5e813cb37d82728d4b
+  languageName: node
+  linkType: hard
+
 "espree@npm:^9.6.0, espree@npm:^9.6.1":
   version: 9.6.1
   resolution: "espree@npm:9.6.1"
@@ -9891,6 +9940,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-is-element@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-is-element@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10/b4e6d84c763ffdc44198ba0c4a5a7430794a7b2c1eec699d37776ea9832eef79f129726c175982103eb3b21f531a6bfd2fa43ce26e1ed6d8f6a87c102ba212c8
+  languageName: node
+  linkType: hard
+
 "hast-util-parse-selector@npm:^4.0.0":
   version: 4.0.0
   resolution: "hast-util-parse-selector@npm:4.0.0"
@@ -9956,6 +10014,18 @@ __metadata:
     web-namespaces: "npm:^2.0.0"
     zwitch: "npm:^2.0.0"
   checksum: 10/ba59d0913ba7e914d8b0a50955c06806a6868445c56796ac9129d58185e86d7ff24037246767aba2ea904d9dee8c09b8ff303630bcd854431fdc1bbee2164c36
+  languageName: node
+  linkType: hard
+
+"hast-util-to-text@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "hast-util-to-text@npm:4.0.2"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    hast-util-is-element: "npm:^3.0.0"
+    unist-util-find-after: "npm:^5.0.0"
+  checksum: 10/71241e486a155b186b06355fa3bbdaa88602aa108a44ab00a6992e5cabcd7858b43dcb1211c5b17bfe76dddbe9acbbd97408a8e483c1ce83834032778bccd157
   languageName: node
   linkType: hard
 
@@ -11774,6 +11844,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"katex@npm:^0.16.0":
+  version: 0.16.22
+  resolution: "katex@npm:0.16.22"
+  dependencies:
+    commander: "npm:^8.3.0"
+  bin:
+    katex: cli.js
+  checksum: 10/fdb8667d9aa971154502b120ba340766754d202e3d3e322aca0a96de27032ad2dbb8a7295d798d310cd7ce4ddd21ed1f3318895541b61c9b4fdf611166589e02
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -12285,6 +12366,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mathjax-full@npm:^3.0.0, mathjax-full@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "mathjax-full@npm:3.2.2"
+  dependencies:
+    esm: "npm:^3.2.25"
+    mhchemparser: "npm:^4.1.0"
+    mj-context-menu: "npm:^0.6.1"
+    speech-rule-engine: "npm:^4.0.6"
+  checksum: 10/1091a1773f736c00723ce4db35f9f0f04f4e54b8af51cf1b916ea0e1f90411e64521970f9ec5f760a7b490956f54cf2a5ddda2a2d762eddf65d6cd63494c4f8c
+  languageName: node
+  linkType: hard
+
 "md5.js@npm:^1.3.4":
   version: 1.3.5
   resolution: "md5.js@npm:1.3.5"
@@ -12313,6 +12406,21 @@ __metadata:
     micromark-util-types: "npm:^2.0.0"
     unist-util-stringify-position: "npm:^4.0.0"
   checksum: 10/69b207913fbcc0469f8c59d922af4d5509b79e809d77c9bd4781543a907fe2ecc8e6433ce0707066a27b117b13f38af3aae4f2d085e18ebd2d3ad5f1a5647902
+  languageName: node
+  linkType: hard
+
+"mdast-util-math@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mdast-util-math@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.1.0"
+    unist-util-remove-position: "npm:^5.0.0"
+  checksum: 10/26f44933f3ae2bfce85df23e79cd31bcc42ef328eaeef70550f38310e29fc8eece5e79fc404ed1485fd38b9113e1817258ca6c1a602be82a933e0198d812c9af
   languageName: node
   linkType: hard
 
@@ -12404,7 +12512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-markdown@npm:^2.0.0":
+"mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0":
   version: 2.1.2
   resolution: "mdast-util-to-markdown@npm:2.1.2"
   dependencies:
@@ -12469,6 +12577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mhchemparser@npm:^4.1.0":
+  version: 4.2.1
+  resolution: "mhchemparser@npm:4.2.1"
+  checksum: 10/06aeb3893a1015c9e66430e4d24a7cd876cc3761aa7258900310f674296ff9797e62d9411bfa0898514100922ccf7bbc9f9eafb34d6bd169177f85df3723a333
+  languageName: node
+  linkType: hard
+
 "micromark-core-commonmark@npm:^2.0.0":
   version: 2.0.3
   resolution: "micromark-core-commonmark@npm:2.0.3"
@@ -12490,6 +12605,21 @@ __metadata:
     micromark-util-symbol: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
   checksum: 10/2b98b9eba1463850ebd8f338f966bd2113dafe764b490ebee3dccab3764d3c48b53fe67673297530e56bf54f58de27dfd1952ed79c5b4e32047cb7f29bd807f2
+  languageName: node
+  linkType: hard
+
+"micromark-extension-math@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "micromark-extension-math@npm:3.1.0"
+  dependencies:
+    "@types/katex": "npm:^0.16.0"
+    devlop: "npm:^1.0.0"
+    katex: "npm:^0.16.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/37b2002aca15cf354ff754191379942f2b36df5ceeb69509294d80b4e158e8af83dda03c434e1497ccc597d63cf85a1ccc0d46f17770fc7692f76887404c8d1d
   languageName: node
   linkType: hard
 
@@ -13010,6 +13140,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10/c075bed1594f68dcc8c35122333520112daefd4d070e5d0a228bd4cf5580e9eed3981b96c0ae1d62488e204e80fd27b2b9d0068ca9a5ef3993e9565faf63ca41
+  languageName: node
+  linkType: hard
+
+"mj-context-menu@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "mj-context-menu@npm:0.6.1"
+  checksum: 10/5b9d6e3dabd9098eb37b9583a55b5e23d9d4f80a97c295c2f4ca318233801519e5abc7b5d7907817fea5cc7dcf334f192ac9622e2d4da55d350b78c8e31e7e3a
   languageName: node
   linkType: hard
 
@@ -15134,6 +15271,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rehype-mathjax@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "rehype-mathjax@npm:7.1.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mathjax": "npm:^0.0.40"
+    hast-util-to-text: "npm:^4.0.0"
+    hastscript: "npm:^9.0.0"
+    mathjax-full: "npm:^3.0.0"
+    unified: "npm:^11.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10/ad9feac793510c2005df1bdc87fa608f2accb447062b42952abcf051f207e0c3157ee8a3f89296d8755fea80e31869770aed8d340c54ac9b159e3d89bffd34a7
+  languageName: node
+  linkType: hard
+
 "rehype-raw@npm:^7.0.0":
   version: 7.0.0
   resolution: "rehype-raw@npm:7.0.0"
@@ -15149,6 +15302,18 @@ __metadata:
   version: 0.2.7
   resolution: "relateurl@npm:0.2.7"
   checksum: 10/f5d6ba58f2a5d5076389090600c243a0ba7072bcf347490a09e4241e2427ccdb260b4e22cea7be4f1fcd3c2bf05908b1e0d0bc9605e3199d4ecf37af1d5681fa
+  languageName: node
+  linkType: hard
+
+"remark-math@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "remark-math@npm:6.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-math: "npm:^3.0.0"
+    micromark-extension-math: "npm:^3.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10/8cd262eadccba1a48bb2353e5b3d0ff18ae6aa2f00adec96458bfd4d414a0763463ff15d2c71d86330bbc355272d6ae7ae2efafba6cb4ae5ba7b7c642394c022
   languageName: node
   linkType: hard
 
@@ -16141,6 +16306,19 @@ __metadata:
   version: 3.0.21
   resolution: "spdx-license-ids@npm:3.0.21"
   checksum: 10/17a033b4c3485f081fc9faa1729dde8782a85d9131b156f2397c71256c2e1663132857d3cba1457c4965f179a4dcf1b69458a31e9d3d0c766d057ef0e3a0b4f2
+  languageName: node
+  linkType: hard
+
+"speech-rule-engine@npm:^4.0.6":
+  version: 4.1.2
+  resolution: "speech-rule-engine@npm:4.1.2"
+  dependencies:
+    "@xmldom/xmldom": "npm:0.9.8"
+    commander: "npm:13.1.0"
+    wicked-good-xpath: "npm:1.3.0"
+  bin:
+    sre: bin/sre
+  checksum: 10/6cbedd3b91e1e11471e3c52e546dd3ca4722269cbcd7488284bf857c83efc250c8d047038e3f03ac38d51b0e79a6368dd1728c9a9f996dce342e11872285d49e
   languageName: node
   linkType: hard
 
@@ -17361,6 +17539,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-find-after@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-find-after@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10/7960f98f99ae3c2585a8e16b23f338e5851b7c0f40c3e82e2aef9ddb4887ae63d4cb3906e793dc8ff8242f252425ef846a4e59afa1d3d91ebf0ac84732df2509
+  languageName: node
+  linkType: hard
+
 "unist-util-inspect@npm:^8.0.0":
   version: 8.1.0
   resolution: "unist-util-inspect@npm:8.1.0"
@@ -17394,6 +17582,16 @@ __metadata:
   dependencies:
     "@types/unist": "npm:^3.0.0"
   checksum: 10/89d4da00e74618d7562ac7ac288961df9bcd4ccca6df3b5a90650f018eceb6b95de6e771e88bdbef46cc9d96861d456abe57b7ad1108921e0feb67c6292aa29d
+  languageName: node
+  linkType: hard
+
+"unist-util-remove-position@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-remove-position@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10/4d89dc25e2091f9d47d92552145a26bf0e4a32d6b453e9cacac7742d730ada186ee1b820579fee3eeaa31e119850c2cb82f8b5898f977a636d7220e998626967
   languageName: node
   linkType: hard
 
@@ -18044,6 +18242,13 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10/6ec99e89ba32c7e748b8a3144e64bfc74aa63e2b2eacbb61a0060ad0b961eb1a632b08fb1de067ed59b002cec3e21de18299216ebf2325ef0f78e0f121e14e90
+  languageName: node
+  linkType: hard
+
+"wicked-good-xpath@npm:1.3.0":
+  version: 1.3.0
+  resolution: "wicked-good-xpath@npm:1.3.0"
+  checksum: 10/e4d7d6c1b48ccb4f406d69217b2fe1073988bcb970645c64be359a1cc81e5aec49d348a7763ad54c7c4a05b6a92986dff7c23edcc5462b54bf1260d52217ace4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7108

### Description (What does it do?)
 adds an optional useMathJax param to the AiChat object to use MathJax to display chat messages

### Screenshots (if appropriate):

<img width="1726" alt="Screenshot 2025-04-28 at 4 39 59 PM" src="https://github.com/user-attachments/assets/3d2a9ee0-f178-4057-a00e-b50bfd5ef544" />

### How can this be tested?
Go to 
http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs 
and verify that mathjax is displayed in the markdown

Follow the steps in 
https://github.com/mitodl/learn-ai/pull/168
