### PR TITLE
feat: Default initial chat messages for problem drawer

### DIFF
--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.stories.tsx
@@ -107,6 +107,23 @@ export const ProblemStory: Story = {
   },
 }
 
+export const ProblemDefaultInitialMessagesStory: Story = {
+  args: {
+    target: "problem-frame-default-initial-messages",
+  },
+  parameters: {
+    payload: {
+      blockType: "problem",
+      target: "problem-frame-default-initial-messages",
+      title: "AskTIM for help with Problem: Derivatives 1.1",
+      chat: {
+        apiUrl: TEST_API_STREAMING,
+        conversationStarters: STARTERS,
+      },
+    },
+  },
+}
+
 export const EntryScreenStory: Story = {
   args: {
     target: "entry-screen-frame",

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.test.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.test.tsx
@@ -7,6 +7,13 @@ import * as React from "react"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
+jest.mock("react-markdown", () => {
+  return {
+    __esModule: true,
+    default: ({ children }: { children: string }) => <div>{children}</div>,
+  }
+})
+
 const TEST_API_STREAMING = "http://localhost:4567/test"
 const CONTENT_FILE_URL = "http://localhost:4567/api/v1/contentfiles/1"
 

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -227,6 +227,14 @@ const useContentFetch = (contentUrl: string | undefined) => {
   return { response, loading }
 }
 
+const DEFAULT_PROBLEM_INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
+  {
+    role: "assistant",
+    content:
+      "Let's try to work on this problem together. It would be great to hear how you're thinking about solving it. Can you walk me through the approach you're considering?",
+  },
+]
+
 const DEFAULT_VIDEO_ENTRY_SCREEN_TITLE =
   "What do you want to know about this video?"
 
@@ -247,6 +255,7 @@ const ChatComponent = ({
   entryScreenEnabled,
   entryScreenTitle,
   conversationStarters,
+  initialMessages,
   hasTabs,
 }: {
   payload: RemoteTutorDrawerInitMessage["payload"]["chat"]
@@ -256,6 +265,7 @@ const ChatComponent = ({
   entryScreenEnabled: boolean
   entryScreenTitle?: AiChatProps["entryScreenTitle"]
   conversationStarters?: AiChatProps["conversationStarters"]
+  initialMessages?: AiChatProps["initialMessages"]
   hasTabs: boolean
 }) => {
   if (!payload) return null
@@ -263,7 +273,7 @@ const ChatComponent = ({
     <StyledAiChat
       chatId={payload.chatId}
       conversationStarters={conversationStarters}
-      initialMessages={payload.initialMessages}
+      initialMessages={initialMessages}
       scrollElement={scrollElement}
       entryScreenEnabled={entryScreenEnabled}
       entryScreenTitle={entryScreenTitle}
@@ -425,6 +435,9 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
           scrollElement={scrollElement}
           entryScreenEnabled={payload.chat?.entryScreenEnabled ?? false}
           entryScreenTitle={payload.chat.entryScreenTitle}
+          initialMessages={
+            payload.chat.initialMessages || DEFAULT_PROBLEM_INITIAL_MESSAGES
+          }
           hasTabs={hasTabs}
         />
       ) : null}
@@ -459,6 +472,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
                 DEFAULT_VIDEO_ENTRY_SCREEN_TITLE
               }
               conversationStarters={conversationStarters}
+              initialMessages={payload.chat.initialMessages}
               hasTabs={hasTabs}
             />
           </StyledTabPanel>


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/7191

### Description (What does it do?)
<!--- Describe your changes in detail -->

Adds default initial chat messages for the Problem drawer.

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/8e0bc6c9-74e1-4e77-93ce-1119861340c3)

### How can this be tested?



Run Storybook (`yarn start`) and visit http://localhost:6006/?path=/docs/smoot-design-ai-remotetutordrawer--docs#problem-default-initial-messages-story. This story demonstrates a problem drawer with no initial messages provided. The default assistant message should be shown: "Let's try to work on this problem together. It would be great to hear how you're thinking about solving it. Can you walk me through the approach you're considering?"



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
