### PR TITLE
fix: Use ai-sdk instead of ai directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           CODECOV: true
           NODE_ENV: test
 
+      - name: Build
+        run: yarn build
+
   build-storybook:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/react": "1.2.10",
     "@emotion/cache": "^11.14.0",
     "@mui/utils": "^6.1.6",
-    "@ai-sdk/react": "^4.0.13",
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react-markdown": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@emotion/cache": "^11.14.0",
     "@mui/utils": "^6.1.6",
-    "ai": "^4.0.13",
+    "@ai-sdk/react": "^4.0.13",
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react-markdown": "^10.0.0",

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -16,7 +16,7 @@ import { Alert } from "../Alert/Alert"
 import { ChatTitle } from "./ChatTitle"
 import { useAiChat } from "./utils"
 import { useScrollSnap } from "../ScrollSnap/useScrollSnap"
-import type { Message } from "ai/react"
+import type { Message } from "@ai-sdk/react"
 
 const classes = {
   root: "MitAiChat--root",

--- a/src/components/AiChat/utils.ts
+++ b/src/components/AiChat/utils.ts
@@ -1,5 +1,5 @@
-import { useChat, UseChatOptions } from "ai/react"
-import type { Message } from "ai/react"
+import { useChat, UseChatOptions } from "@ai-sdk/react"
+import type { Message } from "@ai-sdk/react"
 import type { RequestOpts, AiChatMessage } from "./types"
 import { useMemo } from "react"
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "target": "es6",
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "lib": ["es2020", "dom"],
     "jsx": "react",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,12 +34,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/react@npm:1.2.9":
-  version: 1.2.9
-  resolution: "@ai-sdk/react@npm:1.2.9"
+"@ai-sdk/react@npm:1.2.10":
+  version: 1.2.10
+  resolution: "@ai-sdk/react@npm:1.2.10"
   dependencies:
     "@ai-sdk/provider-utils": "npm:2.2.7"
-    "@ai-sdk/ui-utils": "npm:1.2.8"
+    "@ai-sdk/ui-utils": "npm:1.2.9"
     swr: "npm:^2.2.5"
     throttleit: "npm:2.1.0"
   peerDependencies:
@@ -48,20 +48,20 @@ __metadata:
   peerDependenciesMeta:
     zod:
       optional: true
-  checksum: 10/281759f8cdd84100af0cca4bcc741ea88e087b92c89be4b0b5ea5fb06ffd332917b7c6f8141792efc4655cfd1fba44a97becdae2bbb167ee8dca928b82825d16
+  checksum: 10/4108ea4a3c06728b7b85227bfbf1b6dc76fd09a5d6a1fdc8e30ea056814f29a6ee6a1ba2a2f3a9f8a5f6e7534119b50f2e5e67afbfa31c29b3045fa32993a64b
   languageName: node
   linkType: hard
 
-"@ai-sdk/ui-utils@npm:1.2.8":
-  version: 1.2.8
-  resolution: "@ai-sdk/ui-utils@npm:1.2.8"
+"@ai-sdk/ui-utils@npm:1.2.9":
+  version: 1.2.9
+  resolution: "@ai-sdk/ui-utils@npm:1.2.9"
   dependencies:
     "@ai-sdk/provider": "npm:1.1.3"
     "@ai-sdk/provider-utils": "npm:2.2.7"
     zod-to-json-schema: "npm:^3.24.1"
   peerDependencies:
     zod: ^3.23.8
-  checksum: 10/78a17cd8f7229dbac38f5ec9affdee9808e087791ad37f168ba9a35180b86bf54c8de312c77f3dd15151be8a7494655b6984370fa4704286560c006cf0333dc2
+  checksum: 10/44a39b0455a2631349a51b7ff34ab10d27207c6c41ed908d728b50a22a5b5af6d35107819c770b1017f49d9ec502a9b34d2a8d984deed4ebc5a75ac305df1c07
   languageName: node
   linkType: hard
 
@@ -2785,6 +2785,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mitodl/smoot-design@workspace:."
   dependencies:
+    "@ai-sdk/react": "npm:1.2.10"
     "@chromatic-com/storybook": "npm:^3.0.0"
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.11.1"
@@ -2819,7 +2820,6 @@ __metadata:
     "@types/react-dom": "npm:^19.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.13.0"
     "@typescript-eslint/typescript-estree": "npm:^8.13.0"
-    ai: "npm:^4.0.13"
     classnames: "npm:^2.5.1"
     conventional-changelog-conventionalcommits: "npm:^8.0.0"
     eslint: "npm:8.57.1"
@@ -3619,13 +3619,6 @@ __metadata:
   version: 2.1.0
   resolution: "@open-draft/until@npm:2.1.0"
   checksum: 10/622be42950afc8e89715d0fd6d56cbdcd13e36625e23b174bd3d9f06f80e25f9adf75d6698af93bca1e1bf465b9ce00ec05214a12189b671fb9da0f58215b6f4
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/api@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0"
-  checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
   languageName: node
   linkType: hard
 
@@ -4982,13 +4975,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/diff-match-patch@npm:^1.0.36":
-  version: 1.0.36
-  resolution: "@types/diff-match-patch@npm:1.0.36"
-  checksum: 10/7d7ce03422fcc3e79d0cda26e4748aeb176b75ca4b4e5f38459b112bf24660d628424bdb08d330faefa69039d19a5316e7a102a8ab68b8e294c8346790e55113
-  languageName: node
-  linkType: hard
-
 "@types/doctrine@npm:^0.0.9":
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
@@ -5915,26 +5901,6 @@ __metadata:
     clean-stack: "npm:^5.2.0"
     indent-string: "npm:^5.0.0"
   checksum: 10/37834eb0dac6ebd05ca8aa82e00deeb65fb7b1462c68ccb620221ba1753640fcb249e46c03401b470701a58826b65426deda83783fc2e8347c4b5037b2724d9b
-  languageName: node
-  linkType: hard
-
-"ai@npm:^4.0.13":
-  version: 4.3.10
-  resolution: "ai@npm:4.3.10"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.1.3"
-    "@ai-sdk/provider-utils": "npm:2.2.7"
-    "@ai-sdk/react": "npm:1.2.9"
-    "@ai-sdk/ui-utils": "npm:1.2.8"
-    "@opentelemetry/api": "npm:1.9.0"
-    jsondiffpatch: "npm:0.6.0"
-  peerDependencies:
-    react: ^18 || ^19 || ^19.0.0-rc
-    zod: ^3.23.8
-  peerDependenciesMeta:
-    react:
-      optional: true
-  checksum: 10/f7a7dd0fa7b11202867763a3664e196025d918b50129e185937bc001a8a6a489bb0570def868ca8a44f6c7aa67b73bb7e65c82aadaee23c361deab0f8e32972b
   languageName: node
   linkType: hard
 
@@ -7907,13 +7873,6 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
-  languageName: node
-  linkType: hard
-
-"diff-match-patch@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "diff-match-patch@npm:1.0.5"
-  checksum: 10/fd1ab417eba9559bda752a4dfc9a8ac73fa2ca8b146d29d153964b437168e301c09d8a688fae0cd81d32dc6508a4918a94614213c85df760793f44e245173bb6
   languageName: node
   linkType: hard
 
@@ -11766,19 +11725,6 @@ __metadata:
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
-  languageName: node
-  linkType: hard
-
-"jsondiffpatch@npm:0.6.0":
-  version: 0.6.0
-  resolution: "jsondiffpatch@npm:0.6.0"
-  dependencies:
-    "@types/diff-match-patch": "npm:^1.0.36"
-    chalk: "npm:^5.3.0"
-    diff-match-patch: "npm:^1.0.5"
-  bin:
-    jsondiffpatch: bin/jsondiffpatch.js
-  checksum: 10/124b9797c266c693e69f8d23216e64d5ca4b21a4ec10e3a769a7b8cb19602ba62522f9a3d0c55299c1bfbe5ad955ca9ad2852439ca2c6b6316b8f91a5c218e94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Followup to https://github.com/mitodl/smoot-design/pull/29 because `yarn build` is currently broken on `main`.

### Description (What does it do?)
This PR:
1. Switches us back to `moduleResolution: "node"` from "bundler", which produces an error during `yarn build`.
    ```
    tsconfig.json:7:25 - error TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later.
    
    7     "moduleResolution": "bundler",
                              ~~~~~~~~~
    ````
2. And resolves the type errors encountered in https://github.com/mitodl/smoot-design/pull/29 by using `@ai-sdk/react`.
3. Also adds `yarn build` on CI, which would have caught this issue.

### How can this be tested?
`yarn build` should succeed, and everything should work like before.
