### PR TITLE
chore: make gemini optional

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+---
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false # Don't leave a summary of the PR when opened
+    code_review: false # Only post a code review when prompted


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Makes gemini optional (by request)