### PR TITLE
chore: Improve bundle debugging

### DIFF
--- a/bundle-preview/iframe.html
+++ b/bundle-preview/iframe.html
@@ -4,14 +4,29 @@
     <meta charset="utf-8" />
     <title>Iframe</title>
     <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+      }
       .form {
         display: flex;
         flex-direction: column;
         gap: 1rem;
+        height: 100%;
       }
 
       .form-field {
         display: block;
+        width: 90%;
+      }
+      .payload-field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+      .payload-field > textarea {
+        flex: 1;
       }
 
       .form-field > textarea,
@@ -25,18 +40,16 @@
   <body>
     <form class="form" id="chat-form">
       <button>Open Drawer</button>
-      <label class="form-field">
-        Extra data sent to drawer:
-        <input type="text" name="extra" id="extra" placeholder="Extra" />
-      </label>
 
-      <label class="form-field">
-        API URL
-        <textarea id="api-url" name="apiUrl" rows="3">
-https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
-      </textarea
-        >
+      <label class="form-field payload-field">
+        Payload:
+        <textarea id="payload" name="payload" id="extra" placeholder="Extra">
+        </textarea>
       </label>
+      <div class="form-row">
+        <button id="setProblem" type="button">Set Default Problem Data</button>
+        <button id="setVideo" type="button">Set Default Video Data</button>
+      </div>
     </form>
   </body>
   <script>
@@ -59,20 +72,56 @@ https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
       const formData = new FormData(form)
       const data = Object.fromEntries(formData.entries())
       window.parent.postMessage({
-        type: "smoot-design::chat-open",
-        payload: {
-          askTimTitle: `for help with problems!`,
-          // Get this from user input to allow
-          //  - default: https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
-          //  - other (e.g., local): http://ai.open.odl.local:8005/http/recommendation_agent
-          apiUrl: data.apiUrl.trim(),
-          initialMessages: INITIAL_MESSAGES,
-          conversationStarters: STARTERS,
-          requestBody: {
-            extra: data.extra,
-          },
-        },
+        type: "smoot-design::tutor-drawer-open",
+        payload: JSON.parse(data.payload),
       })
     })
+
+    const setProblem = document.getElementById("setProblem")
+    const setVideo = document.getElementById("setVideo")
+    const payloadField = document.getElementById("payload")
+    const PROBLEM_DATA = {
+      blockType: "problem",
+      title: "AskTIM about Problem 2.4A",
+      chat: {
+        chatId: "318c3d44596649c39fb10c25aa847862", // pragma: allowlist secret
+        apiUrl: "http://ai.open.odl.local:8005/http/tutor_agent/",
+        requestBody: {
+          edx_module_id:
+            "block-v1:MITxT+3.012Sx+3T2024+type@problem+block@318c3d44596649c39fb10c25aa847862",
+          block_siblings: [
+            "block-v1:MITxT+3.012Sx+3T2024+type@problem+block@318c3d44596649c39fb10c25aa847862",
+            "block-v1:MITxT+3.012Sx+3T2024+type@drag-and-drop-v2+block@01a8ff4f311041b784ff392bddc46984",
+            "block-v1:MITxT+3.012Sx+3T2024+type@discussion+block@163eac2433bd42c98a68929ab70cc470",
+          ],
+        },
+      },
+    }
+    const VIDEO_DATA = {
+      blockType: "video",
+      title: "AskTIM about Symmetry in Crystals",
+      chat: {
+        apiUrl: "http://ai.open.odl.local:8005/http/video_gpt_agent/",
+        requestBody: {
+          transcript_asset_id:
+            "asset-v1:MITxT+3.012Sx+3T2024+type@asset+block@ec443d6a-f3b4-4fb6-85e0-8c474b362f84-en.srt",
+        },
+      },
+      summary: {
+        apiUrl:
+          "https://api.rc.learn.mit.edu/learn/api/v1/contentfiles/?edx_module_id=asset-v1%3AMITxT%2B3.012Sx%2B3T2024%2Btype%40asset%2Bblock%40ec443d6a-f3b4-4fb6-85e0-8c474b362f84-en.srt",
+      },
+    }
+
+    const setProblemData = () => {
+      payloadField.value = JSON.stringify(PROBLEM_DATA, null, 2)
+    }
+    const setVideoData = () => {
+      payloadField.value = JSON.stringify(VIDEO_DATA, null, 2)
+    }
+    setProblem.addEventListener("click", setProblemData)
+    setVideo.addEventListener("click", setVideoData)
+
+    setProblemData()
   </script>
 </html>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,7 @@ set -e -o pipefail
 
 rm -rf dist &&
 	rm -f .tsbuildinfo &&
+	node ./scripts/set_version.js &&
 	npm run build:esm &&
 	npm run build:cjs &&
 	npm run build:type-augmentation &&

--- a/scripts/set_version.js
+++ b/scripts/set_version.js
@@ -1,0 +1,18 @@
+const fs = require("fs")
+const path = require("path")
+const package = require("../package.json")
+const VERSION = package.version
+
+// Define outputPath as an absolute path based on __dirname
+const outputPath = path.resolve(__dirname, "../src/VERSION.ts")
+
+// Update the file writing logic to use outputPath
+const versionContent = `
+/**
+ * This file is auto-generated at build time.
+ * Run node ./scripts/set_version.js to update the version.
+ * Do not update this file manually.
+ */
+export const VERSION = "${VERSION}"
+`
+fs.writeFileSync(outputPath, versionContent, "utf8")

--- a/scripts/set_version.js
+++ b/scripts/set_version.js
@@ -12,6 +12,12 @@ const versionContent = `
  * This file is auto-generated at build time.
  * Run node ./scripts/set_version.js to update the version.
  * Do not update this file manually.
+ *
+ * NOTES:
+ * - In development, VERSION will always be "0.0.0"
+ * - The version should not simply be imported from package.json. This would
+ *   result in all of the package.json being included in the bundled code, which
+ *   is not desired.
  */
 export const VERSION = "${VERSION}"
 `

--- a/scripts/set_version.js
+++ b/scripts/set_version.js
@@ -7,8 +7,7 @@ const VERSION = package.version
 const outputPath = path.resolve(__dirname, "../src/VERSION.ts")
 
 // Update the file writing logic to use outputPath
-const versionContent = `
-/**
+const versionContent = `/**
  * This file is auto-generated at build time.
  * Run node ./scripts/set_version.js to update the version.
  * Do not update this file manually.

--- a/src/VERSION.ts
+++ b/src/VERSION.ts
@@ -2,5 +2,11 @@
  * This file is auto-generated at build time.
  * Run node ./scripts/set_version.js to update the version.
  * Do not update this file manually.
+ *
+ * NOTES:
+ * - In development, VERSION will always be "0.0.0"
+ * - The version should not simply be imported from package.json. This would
+ *   result in all of the package.json being included in the bundled code, which
+ *   is not desired.
  */
 export const VERSION = "0.0.0"

--- a/src/VERSION.ts
+++ b/src/VERSION.ts
@@ -1,0 +1,6 @@
+/**
+ * This file is auto-generated at build time.
+ * Run node ./scripts/set_version.js to update the version.
+ * Do not update this file manually.
+ */
+export const VERSION = "0.0.0"

--- a/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
+++ b/src/bundles/RemoteTutorDrawer/RemoteTutorDrawer.tsx
@@ -18,6 +18,7 @@ import type { AiChatProps, AiChatMessage } from "../../components/AiChat/types"
 import { ActionButton } from "../../components/Button/ActionButton"
 import { FlashcardsScreen } from "./FlashcardsScreen"
 import type { Flashcard } from "./FlashcardsScreen"
+import { VERSION } from "../../VERSION"
 
 type RemoteTutorDrawerInitMessage = {
   type: "smoot-design::tutor-drawer-open"
@@ -386,6 +387,7 @@ const RemoteTutorDrawer: FC<RemoteTutorDrawerProps> = ({
   return (
     <Drawer
       data-testid="remote-tutor-drawer"
+      data-smoot-version={VERSION}
       className={className}
       PaperProps={{
         ref: paperRefCallback,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,4 +36,6 @@ export {
   TabButtonList,
 } from "./components/TabButtons/TabButtonList"
 
+export { VERSION } from "./VERSION"
+
 export { VisuallyHidden } from "./components/VisuallyHidden/VisuallyHidden"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
       name: "remoteTutorDrawer",
       fileName: (format) => `remoteTutorDrawer.${format}.js`,
     },
+    sourcemap: true,
   },
   define: {
     "process.env.NODE_ENV": JSON.stringify(mode),


### PR DESCRIPTION
### What are the relevant tickets?
None (Things I worked on while debugging https://github.com/mitodl/hq/issues/7259)

### Description (What does it do?)
This PR:
1. Updates the bundle preview HTML 
2. adds sourcemaps to the `remoteTutorDrawer` bundle
3. embeds `VERSION` in the library code.

### How can this be tested?
1. **Bundle-preview updates:** With [learn-ai](https://github.com/mitodl/learn-ai) running locally with default settings, run `yarn bundle-preview` and navigate to http://localhost:3000/bundle-demo ... The drawer should work. You can test problem/video drawer by clicking the "Set drawer data.." buttons. You can edit the textarea data.
2. Continuing (1), you should be able to see raw source in your browser via sourcemaps, e.g., in Chrome the "Sources" tab:
    
    <img width="600" alt="Screenshot 2025-05-06 at 9 03 35 PM" src="https://github.com/user-attachments/assets/9e25b16a-8def-4155-8bba-c621ae411be2" />
3. You can test the version embedding by noting that https://unpkg.com/@mitodl/smoot-design@0.0.0-1967631/dist/esm/VERSION.js includes the version.