### PR TITLE
fix: Remove drawer rendering into shadow DOM

### DIFF
--- a/src/bundles/remoteTutorDrawer.tsx
+++ b/src/bundles/remoteTutorDrawer.tsx
@@ -17,26 +17,21 @@ import { MathJaxContext } from "better-react-mathjax"
 const init = (opts: RemoteTutorDrawerProps) => {
   const container = document.createElement("div")
   document.body.appendChild(container)
-  const shadowContainer = container.attachShadow({ mode: "open" })
-  const shadowRootEl = document.createElement("div")
-  shadowRootEl.id = "smoot-chat-drawer-root"
-  shadowContainer.append(shadowRootEl)
-  // See https://mui.com/material-ui/customization/shadow-dom/
-  // Ensure style tags are rendered in shadow root
+  container.id = "smoot-chat-drawer-root"
+
   const cache = createCache({
     key: "css",
     prepend: true,
-    container: shadowContainer,
+    container: container,
   })
   const theme = createTheme({
     components: {
-      // Ensure modals, etc, are rendered in shadow root
-      MuiPopover: { defaultProps: { container: shadowRootEl } },
-      MuiPopper: { defaultProps: { container: shadowRootEl } },
-      MuiModal: { defaultProps: { container: shadowRootEl } },
+      MuiPopover: { defaultProps: { container: container } },
+      MuiPopper: { defaultProps: { container: container } },
+      MuiModal: { defaultProps: { container: container } },
     },
   })
-  createRoot(shadowRootEl).render(
+  createRoot(container).render(
     <CacheProvider value={cache}>
       <ThemeProvider theme={theme}>
         <MathJaxContext>
@@ -48,7 +43,6 @@ const init = (opts: RemoteTutorDrawerProps) => {
   )
 
   // Ensure mathjax context menu is rendered above the drawer
-  // NOTE: must be done in regular DOM, not hte shadowdom.
   // Mathjax context menu is appended to end of body.
   const style = document.createElement("style")
   style.textContent = `


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Fixes https://github.com/mitodl/hq/issues/7306

### Description (What does it do?)
<!--- Describe your changes in detail -->

We were rendering the drawer component into the shadow DOM to ensure that styles are isolated, though this impacts focus management as browsers do not reliably traverse the traverse into the shadow root causing our accessibility fixes to ensure that the chat input is focused and that tabs, flashcards and other elements are navigable by keyboard to not work as intended.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

As styles are no longer scoped to the shadow root, this may have the unintended consequence that page styles are applied to the drawer and that the Smoot Design styles impact the page.

This is best tested therefore in the context of an actual application. This can be done by loading an MITx Online page that has a video block, e.g. https://courses-qa.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.012Sx+3T2024/block-v1:MITxT+3.012Sx+3T2024+type@sequential+block@183075df5e164ac387b51ad3d38614c3/block-v1:MITxT+3.012Sx+3T2024+type@vertical+block@09fb1998acce4fd8b4e2c0d14a3e3613. You will need to enroll in [the course](https://rc.mitxonline.mit.edu/courses/course-v1:MITxT+3.012Sx/).

- Run `yarn build:bundle` to produce the dist.

- In the network tab on the MITx page, locate the JS bundle, remoteTutorDrawer.es.js, right click and select "Override content".

<img width="400" alt="image" src="https://github.com/user-attachments/assets/21b38e5f-caa8-4e56-b60d-63228b5106b6" />
<br /><br />

- Copy the local JS bundle at ./dist/bundles/remoteTutorDrawer.es.js into the file in the Sources > Overrides tab or set up local overrides https://developer.chrome.com/docs/devtools/overrides.

- Refresh the page and "AskTIM about this video".

- Test that the chat prompt input is focused when you submit a prompt from the entry screen.

- Test that you can tab focus between the input, close button and navigation tabs.

- Test that you can use left/right arrows to focus between navigation tabs.

- Test that you can use left/right arrows to change flashcards and can use tab to focus between the left and right arrow buttons.



