### PR TITLE
fix: Hide the entry screen if there are user messages

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -231,6 +231,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
     stop,
     error,
     initialMessages,
+    status,
   } = useAiChat()
 
   useScrollSnap({
@@ -245,6 +246,16 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
       promptInputRef.current?.querySelector("input")?.focus()
     }
   }, [showEntryScreen])
+
+  useEffect(() => {
+    if (
+      messages.some(
+        (m) => m.role === "user" || ["submitted", "streaming"].includes(status),
+      )
+    ) {
+      setShowEntryScreen(false)
+    }
+  }, [messages, status])
 
   const showStarters = messages.length === (initialMessages?.length || 0)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://github.com/mitodl/hq/issues/7260

### Description (What does it do?)
<!--- Describe your changes in detail -->

We don't want to display the entry screen to a user that is returning to an existing chat session, however once the AiChat is freshly mounted, the entry screen is always shown if enabled.

This change checks if there are user messages in the chat history or if the chat is in progress and will not show the entry screen.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->


This is best tested on the Learn site - the smoot-design AiDrawer now keeps the drawer mounted and this issue is specifically around returning to a drawer once unmounted.

Over on mit-learn:

- Install the preview package: `yarn up @mitodl/smoot-design@0.0.0-9776b48`
- Open the learning resource drawer on a course.
- Open AskTIM and submit a prompt.
- Close the slidedown and drawer.
- Open the learning resource drawer on the same course.
- Open AskTIM.
- Confirm that you see your previous chat and do not see the entry screen.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
