### PR TITLE
fix: Implement fetch-retry locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@mui/utils": "^6.1.6",
     "better-react-mathjax": "^2.3.0",
     "classnames": "^2.5.1",
-    "fetch-retry": "^6.0.0",
     "lodash": "^4.17.21",
     "react-markdown": "^10.0.0",
     "rehype-mathjax": "^7.1.0",

--- a/src/utils/retryingFetch.ts
+++ b/src/utils/retryingFetch.ts
@@ -1,5 +1,3 @@
-import fetchRetrier from "fetch-retry"
-
 const MAX_RETRIES = 3
 const NO_RETRY_ERROR_CODES = [400, 401, 403, 404, 405, 409, 422]
 const BASE_RETRY_DELAY = process.env.NODE_ENV === "test" ? 10 : 1000
@@ -7,6 +5,86 @@ const BASE_RETRY_DELAY = process.env.NODE_ENV === "test" ? 10 : 1000
 // This is a workaround to ensure retryingFetch uses MSW's fetch version in tests.
 // See https://github.com/jonbern/fetch-retry/issues/95#issuecomment-2613990480
 const fetch: typeof window.fetch = (...args) => window.fetch(...args)
+
+type FetchRetryOptions = {
+  retryDelay: (
+    attempt: number,
+    error: unknown,
+    response: Response | null,
+  ) => number
+  retryOn: (
+    attempt: number,
+    _error: unknown,
+    response: Response | null,
+  ) => boolean
+}
+
+// From https://github.com/jonbern/fetch-retry/blob/master/index.js
+const fetchRetry = (
+  fetch: typeof window.fetch,
+  { retryDelay, retryOn }: FetchRetryOptions,
+): typeof fetch => {
+  return (
+    input: Request | string | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    return new Promise((resolve, reject) => {
+      const wrappedFetch = (attempt: number) => {
+        const _input =
+          typeof Request !== "undefined" && input instanceof Request
+            ? input.clone()
+            : input
+
+        fetch(_input, init)
+          .then((response: Response) => {
+            try {
+              Promise.resolve(retryOn(attempt, null, response))
+                .then((retryOnResponse) => {
+                  if (retryOnResponse) {
+                    retry(attempt, null, response)
+                  } else {
+                    resolve(response)
+                  }
+                })
+                .catch(reject)
+            } catch (error) {
+              reject(error)
+            }
+          })
+          .catch((error) => {
+            try {
+              Promise.resolve(retryOn(attempt, error, null))
+                .then((retryOnResponse) => {
+                  if (retryOnResponse) {
+                    retry(attempt, error, null)
+                  } else {
+                    reject(error)
+                  }
+                })
+                .catch((error) => {
+                  reject(error)
+                })
+            } catch (error) {
+              reject(error)
+            }
+          })
+      }
+
+      const retry = (
+        attempt: number,
+        error: unknown,
+        response: Response | null,
+      ) => {
+        const delay = retryDelay(attempt, error, response)
+        setTimeout(() => {
+          wrappedFetch(++attempt)
+        }, delay)
+      }
+
+      wrappedFetch(0)
+    })
+  }
+}
 
 /**
  * A wrapper around fetch that retries the request on certain error codes.
@@ -25,11 +103,15 @@ const fetch: typeof window.fetch = (...args) => window.fetch(...args)
  *  - When NODE_ENV="test", the maximum retries is set 0 by default but can be
  *  set via the TEST_ENV_MAX_RETRIES environment variable.
  */
-const retryingFetch = fetchRetrier(fetch, {
-  retryDelay: (attempt, _error, _response) => {
+const retryingFetch = fetchRetry(fetch, {
+  retryDelay: (
+    attempt: number,
+    _error: unknown,
+    _response: Response | null,
+  ) => {
     return Math.min(BASE_RETRY_DELAY * 2 ** attempt, 30_000)
   },
-  retryOn: (attempt, _error, response) => {
+  retryOn: (attempt: number, _error: unknown, response: Response | null) => {
     if (attempt >= MAX_RETRIES) {
       return false
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,7 +2834,6 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-styled-components-a11y: "npm:^2.1.35"
     eslint-plugin-testing-library: "npm:^7.0.0"
-    fetch-retry: "npm:^6.0.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.5.0"
     jest-extended: "npm:^4.0.2"
@@ -9227,13 +9226,6 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10/d0000d6b790059b35f4ed19acc8847a66452e0bc68b28766c929ffd523e5ec2083811fc8a545e4a1d4945ce70e887b3a610c145c681073b506143ae3076342ed
-  languageName: node
-  linkType: hard
-
-"fetch-retry@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "fetch-retry@npm:6.0.0"
-  checksum: 10/0c8d3082e2d76fff2df75adef6280bc854bc36fd3ef38506674f0216d0d819e2efd14da7477d3f1732415aea1d2cfde7cd3e1aeae46f45f2adbfc5133296e8de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/hq/issues/7238

### Description (What does it do?)
<!--- Describe your changes in detail -->

Ports a subset of [fetch-retry](https://github.com/jonbern/fetch-retry) into the project.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- No functional change from the main branch.

- Test criteria from https://github.com/mitodl/smoot-design/pull/110 should pass.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

https://github.com/mitodl/smoot-design/pull/110 added [fetch-retry](https://github.com/jonbern/fetch-retry) as a dependency. Upgrading to the latest @mitodl/smoot-design in the MIT Learn project, the app runs without issue, though the Jest unit tests were seeing the error below:

```
  ● Channel Pages, Unit only › Displays the channel logo

    TypeError: (0 , fetch_retry_1.default) is not a function

      at Object.<anonymous> (../../../node_modules/@mitodl/smoot-design/dist/cjs/utils/retryingFetch.js:27:49)
      at Object.<anonymous> (../../../node_modules/@mitodl/smoot-design/dist/cjs/components/AiChat/AiChatContext.js:27:25)
      at Object.<anonymous> (../../../node_modules/@mitodl/smoot-design/dist/cjs/components/AiChat/AiChat.js:28:25)
      at Object.<anonymous> (../../../node_modules/@mitodl/smoot-design/dist/cjs/ai.js:4:16)
      at Object.<anonymous> (page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx:2336:27)
      at Object.<anonymous> (page-components/LearningResourceExpanded/LearningResourceExpanded.tsx:3306:66)
      at Object.<anonymous> (page-components/LearningResourceDrawer/LearningResourceDrawer.tsx:2861:27)
      at require (app-pages/ChannelPage/ChannelPage.tsx:15:5)
```

The `tsc` build complies ESM and CommonJS builds from smoot-design source, excluding any dependencies, which are imported directly in projects. The fetch-retry produces a single [UMD build](https://github.com/jonbern/fetch-retry/blob/master/dist/fetch-retry.umd.js) with Rollup. The app works (uses the UMD version which gets bundled by the app's bundler), though running Jest the tests fail when (using the CJS smoot-design version and the UMD fetch-retry module directly). Jest module system doesn't seem to handle UMD modules as well as modern bundlers.

Given the fetch-retry is small ([full source](https://github.com/jonbern/fetch-retry/blob/master/index.js)), has no dependencies and we are only using a subset of it's API (we provide `retryDelay` and `retryOn` as functions), it makes best sense to find alternatives to fetch-retry that would work better with dual-format packages or just port the code into the project. This PR does the latter.
