### PR TITLE
fix: Add legacy to build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,4 +7,5 @@ rm -rf dist &&
 	npm run build:esm &&
 	npm run build:cjs &&
 	npm run build:type-augmentation &&
-	npm run build:bundles
+	npm run build:bundles &&
+	npm run build:bundles:legacy


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->

RemoteTutorDrawer was renamed to AiDrawerManager in https://github.com/mitodl/smoot-design/pull/116, also renaming the bundle output files. A Vite build config was added to produce the legacy filenames for backwards compatibility, however the package script call was missing from the build script. This adds it in.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn build`
- Confirm that ./dist/bundles/remoteTutorDrawer.es.js is produced.

