### PR TITLE
feat: Add Loading Spinner Icon

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -27,6 +27,11 @@ initialize({
 })
 
 const preview: Preview = {
+  parameters: {
+    docs: {
+      toc: true,
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { Button, ButtonLink } from "./Button"
+import { Button, ButtonLink, ButtonLoadingIcon } from "./Button"
 import type { ButtonProps } from "./Button"
 import Grid from "@mui/material/Grid2"
 import Stack from "@mui/material/Stack"
@@ -13,14 +13,12 @@ import {
 
 import { fn } from "@storybook/test"
 import { enumValues } from "../../story-utils"
-import CircularProgress from "@mui/material/CircularProgress"
 
 const ICONS = {
   None: undefined,
   ArrowBackIcon: <RiArrowLeftLine />,
   DeleteIcon: <RiDeleteBinLine />,
   TestTubeIcon: <RiTestTubeLine />,
-  Loading: <CircularProgress color="inherit" size="1em" />,
 }
 
 const VARIANTS = enumValues<ButtonProps["variant"]>({
@@ -154,6 +152,50 @@ export const Sizes: Story = {
         )
       })}
     </Grid>
+  ),
+}
+
+export const WithLoadingSpinner: Story = {
+  render: (args) => (
+    <Stack direction="row" justifyContent="space-around">
+      <Stack direction="column" alignItems="end" gap={2} sx={{ my: 2 }}>
+        <Button {...args} variant="primary" endIcon={<ButtonLoadingIcon />}>
+          Primary
+        </Button>
+        <Button {...args} variant="secondary" endIcon={<ButtonLoadingIcon />}>
+          Secondary
+        </Button>
+        <Button {...args} variant="tertiary" endIcon={<ButtonLoadingIcon />}>
+          Tertiary
+        </Button>
+      </Stack>
+      <Stack direction="column" alignItems="end" gap={2} sx={{ my: 2 }}>
+        <Button
+          {...args}
+          disabled
+          variant="primary"
+          endIcon={<ButtonLoadingIcon />}
+        >
+          Primary
+        </Button>
+        <Button
+          {...args}
+          disabled
+          variant="secondary"
+          endIcon={<ButtonLoadingIcon />}
+        >
+          Secondary
+        </Button>
+        <Button
+          {...args}
+          disabled
+          variant="tertiary"
+          endIcon={<ButtonLoadingIcon />}
+        >
+          Tertiary
+        </Button>
+      </Stack>
+    </Stack>
   ),
 }
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -13,12 +13,14 @@ import {
 
 import { fn } from "@storybook/test"
 import { enumValues } from "../../story-utils"
+import CircularProgress from "@mui/material/CircularProgress"
 
 const ICONS = {
   None: undefined,
   ArrowBackIcon: <RiArrowLeftLine />,
   DeleteIcon: <RiDeleteBinLine />,
   TestTubeIcon: <RiTestTubeLine />,
+  Loading: <CircularProgress color="inherit" size="1em" />,
 }
 
 const VARIANTS = enumValues<ButtonProps["variant"]>({
@@ -157,12 +159,21 @@ export const Sizes: Story = {
 
 export const WithIcons: Story = {
   render: (args) => (
-    <Stack direction="column" alignItems="start" gap={2} sx={{ my: 2 }}>
-      {Object.entries(ICONS).map(([key, icon]) => (
-        <Button {...args} startIcon={icon} key={key}>
-          {key}
-        </Button>
-      ))}
+    <Stack direction="row" justifyContent="space-around">
+      <Stack direction="column" alignItems="start" gap={2} sx={{ my: 2 }}>
+        {Object.entries(ICONS).map(([key, icon]) => (
+          <Button {...args} startIcon={icon} key={key}>
+            {key}
+          </Button>
+        ))}
+      </Stack>
+      <Stack direction="column" alignItems="end" gap={2} sx={{ my: 2 }}>
+        {Object.entries(ICONS).map(([key, icon]) => (
+          <Button {...args} endIcon={icon} key={key}>
+            {key}
+          </Button>
+        ))}
+      </Stack>
     </Stack>
   ),
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled"
 import { css } from "@emotion/react"
 import { pxToRem } from "../ThemeProvider/typography"
 import type { Theme, ThemeOptions } from "@mui/material/styles"
+import CircularProgress from "@mui/material/CircularProgress"
 import {
   LinkAdapter,
   LinkAdapterPropsOverrides,
@@ -325,8 +326,6 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 )
 
 ButtonLink.displayName = "ButtonLink"
-
-import CircularProgress from "@mui/material/CircularProgress"
 
 /**
  * A loading spinner sized for our buttons; use it as the `startIcon` or `endIcon` prop.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -221,8 +221,25 @@ const ButtonLinkRoot = styled(LinkAdapter, {
   shouldForwardProp: shouldForwardButtonProp,
 })<ButtonStyleProps>(buttonStyles)
 
-const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
-  ({ size, side }) => [
+const iconSizeStyles = (size: ButtonSize) => ({
+  "& > *": {
+    width: "1em",
+    height: "1em",
+    fontSize: pxToRem(
+      {
+        small: 16,
+        medium: 20,
+        large: 24,
+      }[size],
+    ),
+  },
+})
+const IconContainer = styled.span<{
+  side: "start" | "end"
+  size: ButtonSize
+  responsive?: boolean
+}>(({ theme, responsive, side, size }) => {
+  return [
     {
       height: "1em",
       display: "flex",
@@ -241,36 +258,27 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       marginLeft: "8px",
       marginRight: "-4px",
     },
-    {
-      "& svg, & .MuiSvgIcon-root": {
-        width: "1em",
-        height: "1em",
-        fontSize: pxToRem(
-          {
-            small: 16,
-            medium: 20,
-            large: 24,
-          }[size],
-        ),
-      },
+    iconSizeStyles(size),
+    responsive && {
+      [theme.breakpoints.down("sm")]: iconSizeStyles(RESPONSIVE_SIZES[size]),
     },
-  ],
-)
+  ]
+})
 
 const ButtonInner: React.FC<
   ButtonStyleProps & { children?: React.ReactNode }
 > = (props) => {
-  const { children, size = DEFAULT_PROPS.size } = props
+  const { children, size = DEFAULT_PROPS.size, responsive } = props
   return (
     <>
       {props.startIcon ? (
-        <IconContainer size={size} side="start">
+        <IconContainer responsive={responsive} size={size} side="start">
           {props.startIcon}
         </IconContainer>
       ) : null}
       {children}
       {props.endIcon ? (
-        <IconContainer size={size} side="end">
+        <IconContainer responsive={responsive} size={size} side="end">
           {props.endIcon}
         </IconContainer>
       ) : null}
@@ -318,6 +326,27 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 
 ButtonLink.displayName = "ButtonLink"
 
+import CircularProgress from "@mui/material/CircularProgress"
+
+/**
+ * A loading spinner sized for our buttons; use it as the `startIcon` or `endIcon` prop.
+ */
+const ButtonLoadingIcon: React.FC = () => {
+  return (
+    <CircularProgress
+      color="inherit"
+      size="1em"
+      /**
+       * MUI's spinner's viewbox is 44x44, so when we resize this, it ends up being
+       * 5.5 * (24/44) = 3.0px
+       * 5.5 * (20/44) = 2.5px
+       * 5.5 * (16/44) = 2.0px
+       */
+      thickness={5.5}
+    />
+  )
+}
+
 export {
   Button,
   ButtonLink,
@@ -325,6 +354,7 @@ export {
   DEFAULT_PROPS,
   ButtonLinkRoot,
   RESPONSIVE_SIZES,
+  ButtonLoadingIcon,
 }
 
 export type { ButtonProps, ButtonLinkProps, ButtonStyleProps, ButtonSize }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ export {
   createTheme,
 } from "./components/ThemeProvider/ThemeProvider"
 
-export { Button, ButtonLink } from "./components/Button/Button"
+export {
+  Button,
+  ButtonLoadingIcon,
+  ButtonLink,
+} from "./components/Button/Button"
 export type { ButtonProps, ButtonLinkProps } from "./components/Button/Button"
 
 export {


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/7361

### Description (What does it do?)
This PR:
- adds ButtonLoadingIcon for use with Button component
- fixes a small issue with `responsive={true}` and button icons
- adds table of contents to storybook pages

### Screenshots (if appropriate):

<img width="1438" alt="Screenshot 2025-06-10 at 11 28 07 AM" src="https://github.com/user-attachments/assets/7422a34b-c0d5-405c-b6f2-ff26e854b005" />

- This nearly matches https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=313-2307&m=dev, but not quite. See https://github.com/mitodl/hq/issues/7361#issuecomment-2959707135

### How can this be tested?
View http://localhost:6007/?path=/docs/smoot-design-button--docs#with-loading-spinner-3. The spinner should remain centered and be the correct size (16, 20, 24 pixels) and width (2, 2.5, 3 pixels) and color. 


