### PR TITLE
fix: Retain dist files on legacy run

### DIFF
--- a/vite.config.legacy.mts
+++ b/vite.config.legacy.mts
@@ -5,6 +5,7 @@ import { defineConfig } from "vite"
 export default defineConfig(({ mode }) => ({
   build: {
     outDir: "dist/bundled/",
+    emptyOutDir: false,
     lib: {
       entry: [path.resolve(__dirname, "src/bundles/aiDrawerManager.tsx")],
       name: "remoteTutorDrawer",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->



### Description (What does it do?)
<!--- Describe your changes in detail -->

This PR https://github.com/mitodl/smoot-design/pull/124  ensured that the legacy remoteTutorDrawer bundle scripts remain for backwards compatibility (remoteTutorDrawer recently renamed to aiDrawerManager with https://github.com/mitodl/smoot-design/pull/116), however Vite clears the dist output by default, so we are now losing the `aiDrawerManager.<format>.js` files. 

This change configures Vite to not clear the ./dist/bundles folder on the second legacy run.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn build`
- Ensure both aiDrawerManager and remoteTutorDrawer bundle files are present:
```
aiDrawerManager.es.js
aiDrawerManager.es.js.map
aiDrawerManager.umd.js
aiDrawerManager.umd.js.map
remoteTutorDrawer.es.js
remoteTutorDrawer.es.js.map
remoteTutorDrawer.umd.js
remoteTutorDrawer.umd.js.map
```
