### PR TITLE
chore: Simplify keyboard accessibility

### DIFF
--- a/src/bundles/AiDrawer/AiDrawer.stories.tsx
+++ b/src/bundles/AiDrawer/AiDrawer.stories.tsx
@@ -48,6 +48,13 @@ const meta: Meta<typeof AiDrawer> = {
       </>
     )
   },
+  argTypes: {
+    payload: {
+      // JSON controls break form submission via keyboard. See
+      // https://github.com/storybookjs/storybook/issues/31881
+      control: false,
+    },
+  },
 }
 
 export default meta

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -396,10 +396,9 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                   e.preventDefault()
                   if (isLoading && stoppable) {
                     stop()
-                  } else {
-                    scrollToBottom()
-                    handleSubmit(e)
                   }
+                  scrollToBottom()
+                  handleSubmit(e)
                 }}
               >
                 <Input
@@ -419,24 +418,13 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                     isLoading ? (
                       <AdornmentButton
                         aria-label="Stop"
-                        onClick={stop}
+                        type="submit"
                         disabled={!stoppable}
                       >
                         <StyledStopButton />
                       </AdornmentButton>
                     ) : (
-                      <AdornmentButton
-                        aria-label="Send"
-                        type="submit"
-                        onClick={(e) => {
-                          if (input.trim() === "") {
-                            e.preventDefault()
-                            return
-                          }
-                          scrollToBottom()
-                          handleSubmit(e)
-                        }}
-                      >
+                      <AdornmentButton type="submit" aria-label="Send">
                         <StyledSendButton />
                       </AdornmentButton>
                     )

--- a/src/components/AiChat/EntryScreen.tsx
+++ b/src/components/AiChat/EntryScreen.tsx
@@ -6,7 +6,7 @@ import { AdornmentButton, Input } from "../Input/Input"
 import TimLogo from "./TimLogo"
 import { useState } from "react"
 
-const Container = styled.div(({ theme }) => ({
+const Container = styled.form(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
@@ -116,16 +116,15 @@ const EntryScreen = ({
     setPrompt(e.target.value)
   }
 
-  const onPromptKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
-    if (e.key === "Enter" && prompt) {
-      onPromptSubmit(prompt)
-    } else {
-      setPrompt(prompt)
-    }
-  }
-
   return (
-    <Container className={className} data-testid="ai-chat-entry-screen">
+    <Container
+      className={className}
+      data-testid="ai-chat-entry-screen"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onPromptSubmit(prompt)
+      }}
+    >
       <TimLogoBox>
         <RiSparkling2Line />
         <StyledTimLogo />
@@ -134,16 +133,13 @@ const EntryScreen = ({
       <StyledInput
         fullWidth
         size="chat"
+        name="prompt"
         onChange={onPromptChange}
-        onKeyDown={onPromptKeyDown}
         inputProps={{
           "aria-label": "Ask a question",
         }}
         endAdornment={
-          <AdornmentButton
-            aria-label="Send"
-            onClick={() => onPromptSubmit(prompt)}
-          >
+          <AdornmentButton type="submit" aria-label="Send">
             <SendIcon />
           </AdornmentButton>
         }
@@ -155,11 +151,6 @@ const EntryScreen = ({
             key={index}
             onClick={() => onPromptSubmit(content)}
             tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                onPromptSubmit(content)
-              }
-            }}
           >
             <Typography variant="body2">{content}</Typography>
           </Starter>


### PR DESCRIPTION
### What are the relevant tickets?

- Related to https://github.com/mitodl/hq/issues/7632

*I opened this to minimize the number of places we need to make adjustments for the tracking call. It ended up being complicated because of a storybook bug, but it simplifies things and is worthwhile.*

### Description (What does it do?)
This PR removes some redundant keyboard-specific handlers. 

In general, keyboard accessibility is handled automatically by `onClick` and `onSubmit` handlers: Pressing space or Enter on a button automatically fires the click event, and pressing "Enter" with a text input focused submits the associated form. We were previously handling this manually; now using native behavior.

I **suspect** we were handling this manually because of a storybook bug. See https://github.com/storybookjs/storybook/issues/31881

### How can this be tested?

Visit
- http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs
- http://localhost:6006/?path=/docs/smoot-design-ai-aidrawer--docs
- http://localhost:6006/?path=/docs/smoot-design-ai-aidrawermanager--docs

and ensure the chat component still function as expected. You should be able to:
1. **Entry Screen:** Submit queries with "Enter" or by pressing button. The conversation-starters should still be clickable OR triggerable via focus + pressing "Enter".
2. Make the same tests on regular chat screen. 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
