### PR TITLE
feat: Dynamic title in problem set initial message

### DIFF
--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -132,7 +132,7 @@ export const AssignmentSelection: Story = {
     problemSetInitialMessages: [
       {
         role: "assistant",
-        content: "Which question are you working on?",
+        content: "Can I help you with any of the problems in <title>?",
       },
     ],
   },

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -306,7 +306,11 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
     if (problemSetInitialMessages) {
       setMessages(
         problemSetInitialMessages.map((message, i) => ({
-          ...message,
+          content: message.content?.replace(
+            "<title>",
+            event.target.value as string,
+          ),
+          role: message.role,
           id: `initial-${i}`,
         })),
       )

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -132,6 +132,7 @@ type AiChatDisplayProps = {
 
   /**
    * Initial messages to display on problem set selection.
+   * Occurrences of "<title>" in the content will be replaced with the problem set title.
    */
   problemSetInitialMessages?: Omit<AiChatMessage, "id">[]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Additional for https://github.com/mitodl/hq/issues/7974

### Description (What does it do?)
<!--- Describe your changes in detail -->

The `problemSetInitialMessages` can be specified on AiChat props, which are the messages that replace the chat messages once a problem set is selected.

This change will replace occurrences of "<title>" with the selection so we can set e.g. "Can I help you with any of the problems in <title>?" to display as 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->


<img width="970" height="493" alt="image" src="https://github.com/user-attachments/assets/14c087b0-2877-495b-91cd-aafb994c4d45" />


<img width="966" height="414" alt="image" src="https://github.com/user-attachments/assets/27b9d9ee-0e86-4472-b585-e366bd5acc93" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Start Storybook with `yarn start` and navigate to http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs#assignment-selection.

- Select an assignement
- Ensure the assistant message updates with the assignment title, e.g. "Can I help you with any of the problems in Assignment 2?"


