### PR TITLE
fix: Disable prompt submit if problem set not selected

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -259,6 +259,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
   const { response: problemSetListResponse } = useFetch<{
     problem_set_titles: string[]
   }>(problemSetListUrl)
+  const [needsProblemSet, setNeedsProblemSet] = useState(!!problemSetListUrl)
 
   const {
     messages,
@@ -326,6 +327,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
         })),
       )
     }
+    setNeedsProblemSet(!event.target.value)
     setAdditionalBody?.({ problem_set_title: event.target.value as string })
   }
 
@@ -499,12 +501,16 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                       <AdornmentButton
                         aria-label="Stop"
                         type="submit"
-                        disabled={!stoppable}
+                        disabled={!stoppable || needsProblemSet}
                       >
                         <StyledStopButton />
                       </AdornmentButton>
                     ) : (
-                      <AdornmentButton type="submit" aria-label="Send">
+                      <AdornmentButton
+                        type="submit"
+                        aria-label="Send"
+                        disabled={needsProblemSet}
+                      >
                         <StyledSendButton />
                       </AdornmentButton>
                     )

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -501,7 +501,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                       <AdornmentButton
                         aria-label="Stop"
                         type="submit"
-                        disabled={!stoppable || needsProblemSet}
+                        disabled={!stoppable}
                       >
                         <StyledStopButton />
                       </AdornmentButton>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Closes https://github.com/mitodl/hq/issues/8182

### Description (What does it do?)
<!--- Describe your changes in detail -->

The canvas tutor agent endpoint (https://api.rc.learn.mit.edu/ai/http/demo_canvas_tutor_agent/) will reject prompts unless accompanied by a `problem_set_title`.

This PR disables prompt submit until the user has made a selection from the assignment dropdown.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->


- Run `yarn start` to fire up Storybook.

- Navigate to the assignment selection preview at http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs#assignment-selection.

- Ensure that the send button is disabled and that you are not able to submit a prompt by click it or by hitting enter.

- Select a problem set from the assignment dropdown. Ensure that you are now able to submit a prompt.