### PR TITLE
Enable prompt submit if no problem sets

### DIFF
--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -295,6 +295,12 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
   }, [showEntryScreen])
 
   useEffect(() => {
+    if (problemSetListResponse) {
+      setNeedsProblemSet(!!problemSetListResponse.problem_set_titles?.length)
+    }
+  }, [problemSetListResponse])
+
+  useEffect(() => {
     if (
       messages.some(
         (m) => m.role === "user" || ["submitted", "streaming"].includes(status),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Relates to https://github.com/mitodl/hq/issues/8182
- Follow on from https://github.com/mitodl/smoot-design/pull/166

### Description (What does it do?)
<!--- Describe your changes in detail -->

The previous PR disables the prompt submit until a problem set is selected. This enables it if no problem sets are returned.

We would have an issue if there are no problem sets a the initial assistant message asks the user to select one and the cavas tutor agent [endpoint](https://api.rc.learn.mit.edu/ai/http/demo_canvas_tutor_agent/) returns an error is the `problem_set_title` selection is no passed, however from the perspective of the AiChat component it's better to allow the prompt to be submitted so the server can respond accordingly.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Empty the `problem_set_titles` in the mock TEST_API_PROBLEM_SET_LIST response in AiChat.stories.tsx:L49
- Run storybook (`yarn start`) and navigate to the "Assignment Selection" story at http://localhost:6007/?path=/docs/smoot-design-ai-aichat--docs#assignment-selection.
- Note that the assignment selection dropdown is not displayed without values.
- Ensure that the prompt submit is not disabled.
