### PR TITLE
fix: Export the theme object for use outside of provider context

### DIFF
--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -98,5 +98,5 @@ const ThemeProvider: React.FC<ThemeProviderProps> = ({
   return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
 }
 
-export { ThemeProvider, createTheme }
+export { ThemeProvider, createTheme, defaultThemeOptions }
 export type { ThemeProviderProps, Theme }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { css, Global } from "@emotion/react"
 export {
   ThemeProvider,
   createTheme,
+  defaultThemeOptions,
 } from "./components/ThemeProvider/ThemeProvider"
 
 export { Alert } from "./components/Alert/Alert"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/8368

### Description (What does it do?)
<!--- Describe your changes in detail -->

Makes the them option object available for direct import so we can use it in certificate PDF generation and generally outside of React provider contexts.

