### PR TITLE
fix: Defensive styles to resist page overrides on inputs

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/nextjs"
+import styled from "@emotion/styled"
 import { Input, AdornmentButton } from "./Input"
 import type { InputProps } from "./Input"
 import Stack from "@mui/material/Stack"
@@ -125,46 +126,79 @@ export const Adornments: Story = {
   },
 }
 
-export const States: Story = {
+const PageStyles = styled.div(`
+  input {
+    background: red;
+    border: 2px solid blue;
+  }
+
+  input:disabled {
+    background: red;
+
+  }
+
+  input[type="text"] {
+    background: red;
+  }
+
+  .MuiInputBase-input {
+    background: red;
+  }
+`)
+
+/**
+ * Tests that the Input component maintains its intended styling across all states
+ * even when parent page styles attempt to override it. The PageStyles wrapper
+ * includes potentially conflicting CSS that might exist in a consuming application.
+ */
+export const StatesAndParentStyleResistance: Story = {
   render: (args) => {
     return (
-      <Grid container spacing={2} alignItems="center" maxWidth="400px">
-        <Grid size={{ xs: 4 }}>
-          <Typography>Placeholder</Typography>
+      <PageStyles>
+        <Grid container spacing={2} alignItems="center" maxWidth="400px">
+          <Grid size={{ xs: 4 }}>
+            <Typography>Placeholder</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input {...args} value="" />
+          </Grid>
+          <Grid size={{ xs: 4 }}>
+            <Typography>Default</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input {...args} />
+          </Grid>
+          <Grid size={{ xs: 4 }}>
+            <Typography>Initially Focused</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input
+              // This is a story just demonstrating the autofocus prop
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              {...args}
+            />
+          </Grid>
+          <Grid size={{ xs: 4 }}>
+            <Typography>Error</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input {...args} error />
+          </Grid>
+          <Grid size={{ xs: 4 }}>
+            <Typography>Disabled</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input {...args} disabled />
+          </Grid>
+          <Grid size={{ xs: 4 }}>
+            <Typography>Password</Typography>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Input {...args} type="password" />
+          </Grid>
         </Grid>
-        <Grid size={{ xs: 8 }}>
-          <Input {...args} value="" />
-        </Grid>
-        <Grid size={{ xs: 4 }}>
-          <Typography>Default</Typography>
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <Input {...args} />
-        </Grid>
-        <Grid size={{ xs: 4 }}>
-          <Typography>Initially Focused</Typography>
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <Input
-            // This is a story just demonstrating the autofocus prop
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            {...args}
-          />
-        </Grid>
-        <Grid size={{ xs: 4 }}>
-          <Typography>Error</Typography>
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <Input {...args} error />
-        </Grid>
-        <Grid size={{ xs: 4 }}>
-          <Typography>Disabled</Typography>
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <Input {...args} disabled />
-        </Grid>
-      </Grid>
+      </PageStyles>
     )
   },
   args: {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -143,9 +143,15 @@ const baseInputStyles = (theme: Theme) => ({
   overflow: "hidden",
   "&.Mui-disabled": {
     backgroundColor: theme.custom.colors.lightGray1,
+    input: {
+      backgroundColor: "unset",
+    },
   },
   "&:hover:not(.Mui-disabled):not(.Mui-focused)": {
     borderColor: theme.custom.colors.darkGray2,
+    input: {
+      backgroundColor: "unset",
+    },
   },
   "&.Mui-focused": {
     /**
@@ -185,6 +191,15 @@ const baseInputStyles = (theme: Theme) => ({
     input: {
       paddingRight: "8px",
     },
+  },
+  /* Override potentially conflicting styles from parent page to reasonable specificity
+   * - Will override .class1 .class2 input
+   * - Will override .class1 input[type="text"]
+   * - Will not override .class1 .class2 input[type="text"]
+   */
+  "&&& input": {
+    backgroundColor: "unset",
+    border: "none",
   },
 })
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/8608

### Description (What does it do?)
<!--- Describe your changes in detail -->

Unsets background and any border styles that the parent page may apply to ensure the input renders as intended.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

Before:
<img width="550" height="388" alt="image" src="https://github.com/user-attachments/assets/e2d94e0f-c5bb-4d8a-9faf-7bcb5a176dcc" />

After:
<img width="550" height="393" alt="image" src="https://github.com/user-attachments/assets/4a3d7a9c-b734-433b-9bde-1d6c7374801c" />




### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->



The bug in the linked issue is specific to the AiChat as it appears within the mitxonline / lms page, e.g. https://courses.rc.learn.mit.edu/learn/course/course-v1:MITxT+AskTIM.1r+2025_Fall/block-v1:MITxT+AskTIM.1r+2025_Fall+type@sequential+block@ed088b0a26274adc9018146ff9eb83f1/block-v1:MITxT+AskTIM.1r+2025_Fall+type@vertical+block@c469371dc0a948d7b1c8817d9915e46a

The CSS there applies these styles which get applied to the input element:

https://courses.rc.learn.mit.edu/static/mitxonline/css/lms-course.3afbed5d4411.css

```
input[type="text"],input[type="email"],input[type="password"] {
    background: #fff;
    border: 1px solid #c8c8c8;
    ...
}
```

https://courses.rc.learn.mit.edu/static/mitxonline/css/lms-main-v1.d0349bf44338.css
```
textarea,input[type="text"],input[type="url"],input[type="email"],input[type="password"],input[type="tel"] {
    background: #fff;
    border: 1px solid #c8c8c8;
    ...
}
```

The above screenshots show the Storybook story at http://localhost:6006/?path=/docs/smoot-design-input--docs#states-and-parent-style-resistance-1, which has an example page wrapper with some style selectors that are likely to be use in consuming pages.

These include `input[type=text]` to verify the fix.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->




<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
