### PR TITLE
disable postinstall scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.9.3.cjs


### PR DESCRIPTION
### What are the relevant tickets?
None, but in response to https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem

### Description (What does it do?)
Disables postinstall scripts.

From [yarn docs](https://yarnpkg.com/advanced/lifecycle-scripts#postinstall):
> **warning**
> Postinstall scripts should be avoided at all cost, as they make installs slower and riskier. Many users will refuse to install dependencies that have postinstall scripts. Additionally, since the output isn't shown out of the box, using them to print a message to the user will not work as you expect.


### How can this be tested?
Check that:
- `yarn start`
- `yarn pack`

Both still work as expected.
