### PR TITLE
fix: Math \boldsymbol is not rendered

### DIFF
--- a/src/bundles/AiDrawer/AiDrawerManager.tsx
+++ b/src/bundles/AiDrawer/AiDrawerManager.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { useEffect, useState } from "react"
 import { AiDrawer } from "./AiDrawer"
 import type { AiDrawerProps, AiDrawerSettings } from "./AiDrawer"
+import { contentHash } from "../../utils/string"
 
 type AiDrawerInitMessage = {
   type: "smoot-design::ai-drawer-open" | "smoot-design::tutor-drawer-open" // ("smoot-design::tutor-drawer-open" is legacy)
@@ -16,12 +17,7 @@ type AiDrawerInitMessage = {
 
 const hashPayload = (payload: AiDrawerInitMessage["payload"]) => {
   const str = JSON.stringify(payload)
-  let hash = 5381
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash << 5) + hash + str.charCodeAt(i)
-    hash = hash & hash
-  }
-  return Math.abs(hash).toString(36)
+  return contentHash(str)
 }
 
 type AiDrawerManagerProps = {

--- a/src/components/AiChat/AiChat.test.tsx
+++ b/src/components/AiChat/AiChat.test.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable testing-library/await-async-utils */
 import { render, screen, waitFor } from "@testing-library/react"
 import user from "@testing-library/user-event"
-import { AiChat, replaceMathjax } from "./AiChat"
+import { AiChat } from "./AiChat"
+import { replaceMathjax } from "./Markdown"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import * as React from "react"
 import { AiChatProps } from "./types"

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -30,7 +30,18 @@ const ConditionalMathJaxWrapper: React.FC<{
   if (!useMathJax) {
     return <>{children}</>
   }
-  return <MathJaxContext>{children}</MathJaxContext>
+  return (
+    <MathJaxContext
+      config={{
+        loader: { load: ["[tex]/boldsymbol"] },
+        tex: {
+          packages: { "[+]": ["boldsymbol"] },
+        },
+      }}
+    >
+      {children}
+    </MathJaxContext>
+  )
 }
 
 const classes = {
@@ -291,7 +302,9 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
   const [showEntryScreen, setShowEntryScreen] = useState(entryScreenEnabled)
   useEffect(() => {
     if (!showEntryScreen) {
-      promptInputRef.current?.querySelector("input")?.focus()
+      promptInputRef.current
+        ?.querySelector("input")
+        ?.focus({ preventScroll: true })
     }
   }, [showEntryScreen])
 

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -279,7 +279,6 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
   problemSetEmptyMessages,
   ...others // Could contain data attributes
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const chatScreenRef = useRef<HTMLDivElement>(null)
   const promptInputRef = useRef<HTMLDivElement>(null)
@@ -390,7 +389,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
   const externalScroll = !!scrollElement
 
   return (
-    <Container className={className} ref={containerRef}>
+    <Container className={className}>
       {showEntryScreen ? (
         <EntryScreen
           className={classes.entryScreenContainer}
@@ -464,7 +463,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                           message.role === "assistant",
                       })}
                     >
-                      <Message className={className}>
+                      <Message className={classes.message}>
                         <VisuallyHidden
                           as={message.role === "user" ? "h5" : "h6"}
                         >

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -202,6 +202,7 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
  * | `boldsymbol` | no                   | yes                     |
  * | `physics`    | no                   | no                      |
  *
+ * See [https://docs.mathjax.org/en/latest/input/tex/macros/index.html](https://docs.mathjax.org/en/latest/input/tex/macros/index.html)
  *
  * Therefore, we explicitly include boldsymbol in the `loader` configuration
  * to force it to be loaded up front.
@@ -215,7 +216,6 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
  *
  * Note that multiple \<MathJaxContext\> instances on the page share a single state. If they have different configs, only the first is applied.
  *
- * See [https://docs.mathjax.org/en/latest/input/tex/macros/index.html](https://docs.mathjax.org/en/latest/input/tex/macros/index.html)
  */
 export const MathWithExtensionPackages: Story = {
   parameters: {

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled"
 import { handlers } from "./test-utils/api"
 
 const TEST_API_STREAMING = "http://localhost:4567/streaming"
+const TEST_API_STREAMING_MATH = "http://localhost:4567/streaming-math"
 
 const Container = styled.div({
   width: "100%",
@@ -139,7 +140,53 @@ $$
 x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
 
+Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.
+`,
+      },
+    ],
+    useMathJax: true,
+  },
+}
+
+/**
+ * Ensures that LaTeX delimiters `\\(...\\)` and `\\[...\\]`  are rendered correctly.
+ *
+ * better-react-mathjax expects TeX delimiters `$...$` or `$$...$$`, though the LLMs may produce LaTeX delimiters despite instruction.
+ *
+ */
+export const MathLatexDelimiters: Story = {
+  args: {
+    requestOpts: { apiUrl: TEST_API_STREAMING },
+    entryScreenEnabled: false,
+    conversationStarters: [],
+    initialMessages: [
+      {
+        role: "assistant",
+        content: `Some inline math: \\(x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}\\)
+
+And some block math:
+
+\\[
+x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
+\\]
+
 Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
+      },
+    ],
+    useMathJax: true,
+  },
+}
+
+export const MathWithExtensionPackage: Story = {
+  args: {
+    requestOpts: { apiUrl: TEST_API_STREAMING_MATH },
+    entryScreenEnabled: false,
+    conversationStarters: [],
+    initialMessages: [
+      {
+        role: "assistant",
+        content:
+          "Ask me something and I'll respond with math that includes TeX symbols that require an extension package to load (\\boldsymbol)",
       },
     ],
     useMathJax: true,

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -213,7 +213,7 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
  * }
  * ```
  *
- * Note that this does not demo alongside other stories as multiple \<MathJaxContext\> instances on the page share a single state.
+ * Note that multiple \<MathJaxContext\> instances on the page share a single state. If they have different configs, only the first is applied.
  *
  * See [https://docs.mathjax.org/en/latest/input/tex/macros/index.html](https://docs.mathjax.org/en/latest/input/tex/macros/index.html)
  */

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -125,7 +125,7 @@ def f(x):
 /**
  * Shows MathJax rendering of inline and block math.
  *
- * We set startup.typeset to false as by default MathJax will typeset math anywhere on the page and outside of our components - the following should not appear typeset:
+ * We set `startup.typeset` to false in the MathJax config as by default MathJax will typeset math anywhere on the page and outside of our components - the following should not appear typeset:
  * \\(x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}\\)
  */
 export const Math: Story = {
@@ -185,13 +185,13 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
 /**
  * MathJax lazy loads packages for macros not included in its base package as it encounters them.
  *
- * The assistant response to prompts below includes some of these.
+ * The assistant response below includes some of these.
  *
- * - \boldsymbol - the boldsymbol package is autoloaded, however we have seen timing issues where the response is not typeset if the package does not load in time. As a result we have included it in the MathJax config to preload.
+ * - `\boldsymbol` - the boldsymbol package is autoloaded, however we have seen timing issues where the response is not typeset if the package does not load in time. As a result we have included it in the MathJax config to preload.
  *
- * - ams - the AMS package is included in the base MathJax package (https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js).
+ * - `ams` - the AMS package is included in the base MathJax package ([https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js](https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js)).
  *
- * - physics - the physics package is not autoloaded and will _not_ render by default. If we want to render physics symbols, we will need to include it in the MathJax config.
+ * - `physics` - the physics package is not autoloaded and will _not_ render by default. If we want to render physics symbols, we will need to include it in the MathJax config.
  *
  * `mathJaxConfig` is available as a prop. To load the physics package, we can set:
  *
@@ -202,9 +202,9 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
  * }
  * ```
  *
- * Note that this does not demo alongside other stories as  multiple <MathJaxContext> instances on the page share a single state.
+ * Note that this does not demo alongside other stories as multiple \<MathJaxContext\> instances on the page share a single state.
  *
- * See https://docs.mathjax.org/en/latest/input/tex/macros/index.html
+ * See [https://docs.mathjax.org/en/latest/input/tex/macros/index.html](https://docs.mathjax.org/en/latest/input/tex/macros/index.html)
  */
 export const MathWithExtensionPackages: Story = {
   parameters: {

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -9,7 +9,6 @@ const TEST_API_STREAMING_MATH = "http://localhost:4567/streaming-math"
 
 const Container = styled.div({
   width: "100%",
-  height: "500px",
 })
 
 const meta: Meta<typeof AiChat> = {
@@ -21,7 +20,7 @@ const meta: Meta<typeof AiChat> = {
   render: (args) => <AiChat {...args} />,
   decorators: (Story, context) => {
     return (
-      <Container>
+      <Container style={{ height: context.parameters.height || "500px" }}>
         <Story key={String(context.args.entryScreenEnabled)} />
       </Container>
     )
@@ -123,6 +122,12 @@ def f(x):
   },
 }
 
+/**
+ * Shows MathJax rendering of inline and block math.
+ *
+ * We set startup.typeset to false as by default MathJax will typeset math anywhere on the page and outside of our components - the following should not appear typeset:
+ * \\(x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}\\)
+ */
 export const Math: Story = {
   args: {
     requestOpts: { apiUrl: TEST_API_STREAMING },
@@ -177,7 +182,34 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
   },
 }
 
-export const MathWithExtensionPackage: Story = {
+/**
+ * MathJax lazy loads packages for macros not included in its base package as it encounters them.
+ *
+ * The assistant response to prompts below includes some of these.
+ *
+ * - \boldsymbol - the boldsymbol package is autoloaded, however we have seen timing issues where the response is not typeset if the package does not load in time. As a result we have included it in the MathJax config to preload.
+ *
+ * - ams - the AMS package is included in the base MathJax package (https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js).
+ *
+ * - physics - the physics package is not autoloaded and will _not_ render by default. If we want to render physics symbols, we will need to include it in the MathJax config.
+ *
+ * `mathJaxConfig` is available as a prop. To load the physics package, we can set:
+ *
+ * ```tsx
+ * mathJaxConfig: {
+ *   loader: { load: ["[tex]/physics"] },
+ *   tex: { packages: { "[+]": ["physics"] } },
+ * }
+ * ```
+ *
+ * Note that this does not demo alongside other stories as  multiple <MathJaxContext> instances on the page share a single state.
+ *
+ * See https://docs.mathjax.org/en/latest/input/tex/macros/index.html
+ */
+export const MathWithExtensionPackages: Story = {
+  parameters: {
+    height: "800px",
+  },
   args: {
     requestOpts: { apiUrl: TEST_API_STREAMING_MATH },
     entryScreenEnabled: false,
@@ -186,7 +218,7 @@ export const MathWithExtensionPackage: Story = {
       {
         role: "assistant",
         content:
-          "Ask me something and I'll respond with math that includes TeX symbols that require an extension package to load (\\boldsymbol)",
+          "Ask me something and I'll respond with math that includes TeX symbols that are not in the base MathJax package",
       },
     ],
     useMathJax: true,

--- a/src/components/AiChat/AiChatMarkdown.stories.tsx
+++ b/src/components/AiChat/AiChatMarkdown.stories.tsx
@@ -183,17 +183,28 @@ Math is rendered using MathJax only if the \`useMathJax\` prop is set to true.`,
 }
 
 /**
- * MathJax lazy loads packages for macros not included in its base package as it encounters them.
+ * > **⚠ NOTE:** Although the `boldsymbol` package is lazily loaded by default,
+ * > we have found that on slow networks a race condition can occur resulting in
+ * > un-rendered boldsymbol commands. This behavior can be reproduced by removing
+ * > the `loader` configuration that explicitly loads the `boldsymbol` package
+ * > and using a throttled network connection.
  *
- * The assistant response below includes some of these.
+ * This story demonstrates math rendering of LaTeX commands from specialized
+ * packages. MathJax includes some packages in its base configuration, loads
+ * some packages lazily on demand ("autoloads"), and requires some packages to
+ * be explicitly loaded.
  *
- * - `\boldsymbol` - the boldsymbol package is autoloaded, however we have seen timing issues where the response is not typeset if the package does not load in time. As a result we have included it in the MathJax config to preload.
+ * The responses here demonstrate commands from the following packages:
  *
- * - `ams` - the AMS package is included in the base MathJax package ([https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js](https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js)).
+ * | Package    | Included by default? | Lazy loaded by default? |
+ * |------------|----------------------|-------------------------|
+ * | `ams`        | yes                  | n/a                     |
+ * | `boldsymbol` | no                   | yes                     |
+ * | `physics`    | no                   | no                      |
  *
- * - `physics` - the physics package is not autoloaded and will _not_ render by default. If we want to render physics symbols, we will need to include it in the MathJax config.
  *
- * `mathJaxConfig` is available as a prop. To load the physics package, we can set:
+ * Therefore, we explicitly include boldsymbol in the `loader` configuration
+ * to force it to be loaded up front.
  *
  * ```tsx
  * mathJaxConfig: {

--- a/src/components/AiChat/Markdown.tsx
+++ b/src/components/AiChat/Markdown.tsx
@@ -1,20 +1,44 @@
 import * as React from "react"
+import { useMemo } from "react"
 import ReactMarkdown from "react-markdown"
 import rehypeMathjax from "rehype-mathjax/browser"
 import remarkMath from "remark-math"
 import { MathJax } from "better-react-mathjax"
 import remarkSupersub from "remark-supersub"
+import { contentHash } from "../../utils/string"
+
+/**
+ * Component that provides isolation between React and MathJax DOM manipulation.
+ *
+ * Seeing errors e.g. Error: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
+ *
+ * MathJax manipulates the DOM directly, and when React tries to reconcile during updates during streaming, it encounters DOM nodes that MathJax has modified or replaced.
+ *
+ * Here we hash the content to provide a key to ensure React creates new DOM elements when the content changes instead of trying to reconcile with MathJax modifications.
+ */
+const MathJaxWrapper: React.FC<{
+  children: React.ReactElement<{ children: string }>
+}> = ({ children }) => {
+  const contentKey = useMemo(() => {
+    return contentHash(children.props.children || "")
+  }, [children])
+  return (
+    <MathJax key={contentKey} style={{ isolation: "isolate" }}>
+      {children}
+    </MathJax>
+  )
+}
 
 type MarkdownProps = {
   children?: string
-  enableMathjax?: boolean
+  useMathJax?: boolean
 }
 
-const Markdown: React.FC<MarkdownProps> = ({ children, enableMathjax }) => {
-  const remarkPlugins = enableMathjax
+const Markdown: React.FC<MarkdownProps> = ({ children, useMathJax }) => {
+  const remarkPlugins = useMathJax
     ? [remarkMath, remarkSupersub]
     : [remarkSupersub]
-  const rehypePlugins = enableMathjax ? [rehypeMathjax] : undefined
+  const rehypePlugins = useMathJax ? [rehypeMathjax] : undefined
 
   const markdown = (
     <ReactMarkdown
@@ -29,11 +53,28 @@ const Markdown: React.FC<MarkdownProps> = ({ children, enableMathjax }) => {
         ),
       }}
     >
-      {children}
+      {useMathJax ? replaceMathjax(children || "") : children}
     </ReactMarkdown>
   )
 
-  return enableMathjax ? <MathJax>{markdown}</MathJax> : markdown
+  return useMathJax ? <MathJaxWrapper>{markdown}</MathJaxWrapper> : markdown
+}
+
+// react-markdown expects Mathjax delimiters to be $...$ or $$...$$
+// the prompt for the tutorbot asks for Mathjax tags with $ format but
+// the LLM does not get it right all the time
+// this function replaces the Mathjax tags with the correct format
+// eventually we will probably be able to remove this as LLMs get better
+function replaceMathjax(inputString: string): string {
+  // Replace instances of \(...\) and \[...\] Mathjax tags with $...$
+  // and $$...$$ tags.
+  const INLINE_MATH_REGEX = /\\\((.*?)\\\)/g
+  const DISPLAY_MATH_REGEX = /\\\[(([\s\S]*?))\\\]/g
+  inputString = inputString.replace(
+    INLINE_MATH_REGEX,
+    (_match, p1) => `$${p1}$`,
+  )
+  return inputString.replace(DISPLAY_MATH_REGEX, (_match, p1) => `$$${p1}$$`)
 }
 
 export default Markdown

--- a/src/components/AiChat/Markdown.tsx
+++ b/src/components/AiChat/Markdown.tsx
@@ -78,3 +78,4 @@ function replaceMathjax(inputString: string): string {
 }
 
 export default Markdown
+export { replaceMathjax }

--- a/src/components/AiChat/Markdown.tsx
+++ b/src/components/AiChat/Markdown.tsx
@@ -9,6 +9,7 @@ type MarkdownProps = {
   children?: string
   enableMathjax?: boolean
 }
+
 const Markdown: React.FC<MarkdownProps> = ({ children, enableMathjax }) => {
   const remarkPlugins = enableMathjax
     ? [remarkMath, remarkSupersub]

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -98,7 +98,129 @@ Start by thinking about what the perturbation $\\mathbf{\\Delta}$ represents in 
 
 Once you have a sense of these relationships, consider how you might manipulate the expressions to show they are equivalent. What properties of norms and perturbations can you use to bridge the gap between these two formulations?
 
-Feel free to share your thoughts or any initial ideas you have!`,
+Here's an advanced mathematical analysis involving various AMS symbols and operators:
+
+## Analysis with AMS Symbols
+
+Let's explore some advanced mathematical concepts using specialized notation:
+
+### Approximation and Equivalence Relations
+
+The function $f(x)$ can be approximated as:
+$$f(x) \\approxeq g(x) + O(h^2)$$
+
+where $g(x) \\asymp h(x)$ for large values of $x$.
+
+### Set Theory and Logic
+
+Consider the following relationships:
+$$A \\subseteq B \\iff \\forall x \\in A, x \\in B$$
+$$A \\subsetneq B \\iff A \\subseteq B \\land A \\neq B$$
+
+The symmetric difference is defined as:
+$$A \\triangle B = (A \\setminus B) \\cup (B \\setminus A)$$
+
+### Advanced Inequalities and Comparisons
+
+For sequences $\\{a_n\\}$ and $\\{b_n\\}$:
+$$a_n \\lesssim b_n \\iff \\limsup_{n \\to \\infty} \\frac{a_n}{b_n} < \\infty$$
+$$a_n \\gtrsim b_n \\iff b_n \\lesssim a_n$$
+$$a_n \\eqsim b_n \\iff a_n \\lesssim b_n \\land b_n \\lesssim a_n$$
+
+### Geometric Relations
+
+In geometric analysis, we often encounter:
+$$\\angle ABC \\cong \\angle DEF$$
+$$\\triangle ABC \\sim \\triangle XYZ$$
+
+Where lines can be:
+- Parallel: $\\ell_1 \\parallel \\ell_2$
+- Perpendicular: $\\ell_1 \\perp \\ell_2$
+
+### Advanced Operators
+
+The convolution operator:
+$$f \\ast g = \\int_{-\\infty}^{\\infty} f(t)g(x-t) dt$$
+
+And the composition:
+$$f \\circ g = f(g(x))$$
+
+### Logical Implications
+
+$$P \\implies Q \\iff \\neg P \\lor Q$$
+$$P \\iff Q \\iff (P \\implies Q) \\land (Q \\implies P)$$
+
+These symbols are essential in advanced mathematical notation and provide precise ways to express complex relationships.
+
+## Physics Package Examples
+
+The physics package provides convenient macros for mathematical notation commonly used in physics:
+
+#### Absolute Values and Norms
+$$\\abs{x} = |x|$$
+$$\\absolutevalue{\\psi} = |\\psi|$$
+
+#### Trigonometric Functions
+$$\\acos{x} = \\arccos(x)$$
+$$\\acosine{x} = \\arccos(x)$$
+$$\\acomm{A}{B} = [A, B]_+$$
+
+#### Inverse Trigonometric Functions
+$$\\acosecant{x} = \\csc^{-1}(x)$$
+$$\\acsc{x} = \\csc^{-1}(x)$$
+$$\\acot{x} = \\cot^{-1}(x)$$
+$$\\acotangent{x} = \\cot^{-1}(x)$$
+
+#### Derivatives and Differentials
+$$\\dd{x} \\quad \\text{differential}$$
+$$\\dv{f}{x} = \\frac{df}{dx} \\quad \\text{derivative}$$
+$$\\pdv{f}{x} = \\frac{\\partial f}{\\partial x} \\quad \\text{partial derivative}$$
+$$\\fdv{f}{x}{y} = \\frac{d^2f}{dxdy} \\quad \\text{functional derivative}$$
+
+#### Vector Notation
+$$\\vb{v} = \\mathbf{v} \\quad \\text{vector bold}$$
+$$\\vb*{F} = \\vec{F} \\quad \\text{vector arrow}$$
+$$\\vu{n} = \\hat{n} \\quad \\text{unit vector}$$
+$$\\va{a} = \\vec{a} \\quad \\text{vector arrow}$$
+
+#### Vector Operations
+$$\\grad f = \\nabla f \\quad \\text{gradient}$$
+$$\\div \\vb{F} = \\nabla \\cdot \\vb{F} \\quad \\text{divergence}$$
+$$\\curl \\vb{F} = \\nabla \\times \\vb{F} \\quad \\text{curl}$$
+$$\\laplacian f = \\nabla^2 f \\quad \\text{laplacian}$$
+
+#### Quantum Mechanics
+$$\\bra{\\psi} \\quad \\text{bra notation}$$
+$$\\ket{\\phi} \\quad \\text{ket notation}$$
+$$\\braket{\\psi}{\\phi} \\quad \\text{inner product}$$
+$$\\ketbra{\\psi}{\\phi} \\quad \\text{outer product}$$
+$$\\expectationvalue{A}{\\psi} = \\langle\\psi|A|\\psi\\rangle \\quad \\text{expectation value}$$
+$$\\matrixelement{i}{A}{j} = \\langle i|A|j\\rangle \\quad \\text{matrix element}$$
+
+#### Commutators and Anticommutators
+$$\\comm{A}{B} = [A,B] = AB - BA \\quad \\text{commutator}$$
+$$\\acomm{A}{B} = \\{A,B\\} = AB + BA \\quad \\text{anticommutator}$$
+$$\\poissonbracket{f}{g} = \\{f,g\\} \\quad \\text{Poisson bracket}$$
+
+#### Matrix Notation
+$$\\mqty(a & b \\\\ c & d) \\quad \\text{matrix quantity with parentheses}$$
+$$\\mqty[a & b \\\\ c & d] \\quad \\text{matrix quantity with brackets}$$
+$$\\pqty{\\frac{a}{b}} \\quad \\text{parentheses quantity}$$
+$$\\bqty{\\frac{a}{b}} \\quad \\text{bracket quantity}$$
+
+#### Special Functions and Constants
+$$\\Re{z} \\quad \\text{real part}$$
+$$\\Im{z} \\quad \\text{imaginary part}$$
+$$\\Tr{A} \\quad \\text{trace}$$
+$$\\det{A} \\quad \\text{determinant}$$
+$$\\rank{A} \\quad \\text{rank}$$
+$$\\norm{\\vb{v}} \\quad \\text{norm}$$
+
+#### Order and Evaluation
+$$\\order{x^2} \\quad \\text{order notation}$$
+$$\\eval{f(x)}_{x=0} \\quad \\text{evaluated at}$$
+$$\\qty(\\frac{\\partial f}{\\partial x})_{y} \\quad \\text{quantity with subscript}$$
+`,
 ]
 
 const rand = (min: number, max: number) => {

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -82,6 +82,23 @@ $$
 x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
 `,
+  `Great question! Let's start by understanding what the problem is asking. You need to prove that the Adaptive Lasso is equivalent to a robust regression problem with a specific perturbation in the data matrix.
+
+To begin, consider the two expressions given in the problem:
+
+1. The Adaptive Lasso objective:
+   $$\\min_{\\boldsymbol{\\beta}} \\| \\mathbf{y} - \\mathbf{X} \\boldsymbol{\\beta} \\|_2 + \\lambda \\| \\mathbf{W}\\boldsymbol{\\beta}\\|_1$$
+
+2. The robust regression problem:
+   $$\\min_{\\boldsymbol{\\beta}} \\max_{ \\mathbf{\\Delta} \\in \\mathcal{U}} \\| \\mathbf{y} - (\\mathbf{X} + \\mathbf{\\Delta} )\\boldsymbol{\\beta} \\|_2$$
+
+The goal is to show that these two are equivalent.
+
+Start by thinking about what the perturbation $\\mathbf{\\Delta}$ represents in the context of the robust regression problem. How does it relate to the weights $\\mathbf{W}$ in the Adaptive Lasso? What role does the uncertainty set $\\mathcal{U}$ play in this equivalence?
+
+Once you have a sense of these relationships, consider how you might manipulate the expressions to show they are equivalent. What properties of norms and perturbations can you use to bridge the gap between these two formulations?
+
+Feel free to share your thoughts or any initial ideas you have!`,
 ]
 
 const rand = (min: number, max: number) => {
@@ -89,9 +106,10 @@ const rand = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min)
 }
 
-const getReadableStream = () => {
+const getReadableStream = (index?: number) => {
   let timerId: NodeJS.Timeout
-  const response = SAMPLE_RESPONSES[rand(0, SAMPLE_RESPONSES.length - 1)]
+  const response =
+    SAMPLE_RESPONSES[index ?? rand(0, SAMPLE_RESPONSES.length - 1)]
   const chunks: string[] = response.split(" ").reduce((acc, word) => {
     const last = acc[acc.length - 1]
     if (acc.length === 0) {
@@ -143,6 +161,15 @@ const handlers = [
       }
     }
 
+    return new HttpResponse(body, {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    })
+  }),
+  http.post("http://localhost:4567/streaming-math", async () => {
+    await delay(600)
+    const body = getReadableStream(4)
     return new HttpResponse(body, {
       headers: {
         "Content-Type": "text/plain",

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -1,6 +1,7 @@
 // Some of these are based on (compatible, but simplified / restricted) versions of @ai-sdk/react types.
 
 import { RefAttributes } from "react"
+import { type MathJax3Config } from "better-react-mathjax"
 
 type Role = "assistant" | "user"
 
@@ -116,6 +117,12 @@ type AiChatDisplayProps = {
    * Defaults to false.
    */
   useMathJax?: boolean
+
+  /**
+   * Ovverrides the default MathJax configuration.
+   */
+  mathJaxConfig?: MathJax3Config
+
   /**
    * If true, the chat input will be autofocused on load.
    * Defaults to true.

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -1,7 +1,7 @@
 // Some of these are based on (compatible, but simplified / restricted) versions of @ai-sdk/react types.
 
 import { RefAttributes } from "react"
-import { type MathJax3Config } from "better-react-mathjax"
+import type { MathJax3Config } from "better-react-mathjax"
 
 type Role = "assistant" | "user"
 
@@ -119,7 +119,7 @@ type AiChatDisplayProps = {
   useMathJax?: boolean
 
   /**
-   * Ovverrides the default MathJax configuration.
+   * Overrides the default MathJax configuration.
    */
   mathJaxConfig?: MathJax3Config
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,8 @@
+export const contentHash = (str: string) => {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) + hash + str.charCodeAt(i)
+    hash = hash & hash
+  }
+  return Math.abs(hash).toString(36)
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Fixes: https://github.com/mitodl/hq/issues/8694

### Description (What does it do?)
<!--- Describe your changes in detail -->

**Preloads the \boldsymbol MathJax/TeX extension to ensure it is available when rendered.**

There is a race condition around the load timing of the boldsymbol extension script and the render.

1. better-react-mathjax loads the base MathJax on load - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.js
2. The chat endpoint responds with math that includes \boldsymbol (assuming here that there is no use of \boldsymbol in initial messages - the problem doesn't present when included in first render).
3. The MathJax script loads the boldsymbol extension script on demand when encountered - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/input/tex/extensions/boldsymbol.js
4. Depending on response time, /boldsymbol is not typeset and is displayed raw.

The solution is to add it to the loaded config on better-react-mathjax. Ideally we don't want to load extra scripts on the page for macros that will not appear in the majority of cases, but various other attempts to [typeset dynamically](https://github.com/fast-reflexes/better-react-mathjax?tab=readme-ov-file#dynamic-boolean--undefined) or defer were not fruitful.

**Provides `mathJaxConfig` as a prop for pages to determine which TeX packages to render (plus other [config](https://docs.mathjax.org/en/latest/web/configuration.html)).**

This will enable a page for a physics course for example to load the physics package:

```tsx
mathJaxConfig: {
   loader: { load: ["[tex]/physics"] },
   tex: { packages: { "[+]": ["physics"] } },
}
```

**Provides a fix for a MathJax/React reconciliation error.**

The issue was that MathJax manipulates DOM nodes to render math expressions, but when React attempts to reconcile during streaming updates, it encounters nodes that MathJax has modified or replaced, leading to errors like:

```
Error: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

The fix hashes the message content to generate component keys to ensure a fresh DOM tree for each update.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->


<img width="906" height="188"  alt="image" src="https://github.com/user-attachments/assets/98c1c53b-cf6a-4c62-9081-07da54e73c5d" style="border: 1px solid gray;" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Start Storybook, `yarn start`
- Navigate to "Math With Extension Packages" story http://localhost:6006/?path=/docs/smoot-design-ai-aichat-markdown--docs#math-with-extension-packages
  - This story is designed to to test the deferred script load race condition case by including \boldsymbol in the chat response, but not the initial messages.
- In dev tools, throttle to 3G in the network tab.
- Enter a prompt and observe that the math renders, typesetting \boldsymbol. 
- The fix is best verified by a reversion test.
  - Comment out the boldsymbol `loader` and `tex.packages` config in AiChat.tsx L42-45.
  - Refresh the Storybook page without network throttle.
  - Throttle to 3G.
  - Enter a prompt.
  - Observe that \boldsymbol is not typeset:
 
<img width="947" height="79" alt="image" src="https://github.com/user-attachments/assets/fecda643-2c43-4e92-ae50-6aabb923c0ac" style="border: 1px solid gray;" />


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
