### PR TITLE
feat: Chat feedback buttons

### DIFF
--- a/src/components/AiChat/AiChat.test.tsx
+++ b/src/components/AiChat/AiChat.test.tsx
@@ -19,6 +19,12 @@ const server = setupServer(
     counter()
     return HttpResponse.text(`AI Response ${count}`)
   }),
+  http.post(
+    "http://localhost:4567/ai/api/v0/chat_sessions/:threadId/messages/:checkpointPk/rate/",
+    async () => {
+      return HttpResponse.json({ message: "Feedback received" })
+    },
+  ),
 )
 beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())
@@ -291,6 +297,7 @@ describe("AiChat", () => {
   })
 
   test("csrfCookieName and csrfHeaderName are used to set CSRF token if provided", async () => {
+    const mockFetch = jest.spyOn(window, "fetch")
     const csrfCookieName = "my-csrf-cookie"
     const csrfHeaderName = "My-Csrf-Header"
     document.cookie = `${csrfCookieName}=test-csrf-token`
@@ -304,12 +311,38 @@ describe("AiChat", () => {
 
     await user.click(getConversationStarters()[0])
 
-    expect(window.fetch).toHaveBeenCalledWith(
+    expect(mockFetch).toHaveBeenCalledWith(
       API_URL,
       expect.objectContaining({
         headers: expect.objectContaining({
           [csrfHeaderName]: "test-csrf-token",
         }),
+      }),
+    )
+  })
+
+  test("extractCommentsAndParseJson integration - message data is extracted from comments", async () => {
+    const mockFetch = jest.spyOn(window, "fetch")
+    const { initialMessages } = setup({
+      requestOpts: { apiUrl: API_URL },
+    })
+
+    server.use(
+      http.post(API_URL, async () => {
+        return HttpResponse.text(`Here is a response.
+
+<!-- {"checkpoint_pk": 123, "thread_id": "f8a2b9c4e7d6f1a3b5c8e9d2f4a7b6c1"} -->`)
+      }),
+    )
+
+    await user.click(getConversationStarters()[0])
+    await whenCount(getMessages, initialMessages.length + 2)
+    await user.click(screen.getByRole("button", { name: "Like" }))
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:4567/ai/api/v0/chat_sessions/f8a2b9c4e7d6f1a3b5c8e9d2f4a7b6c1/messages/123/rate/",
+      expect.objectContaining({
+        body: JSON.stringify({ rating: "like" }),
       }),
     )
   })

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -32,6 +32,7 @@ import type { MathJax3Config } from "better-react-mathjax"
 import { MathJaxContext } from "better-react-mathjax"
 import deepmerge from "@mui/utils/deepmerge"
 import { ActionButton } from "../Button/ActionButton"
+import { Tooltip } from "../Tooltip/Tooltip"
 
 const ConditionalMathJaxWrapper: React.FC<{
   useMathJax: boolean
@@ -272,12 +273,16 @@ const StyledEllipsisIcon = styled(EllipsisIcon)(({ theme }) => ({
 const FeedbackRowContainer = styled.div({
   display: "flex",
   gap: "4px",
-  marginTop: "16px",
+  margin: "16px 0 10px 0",
 })
 
 const FeedbackButton = styled(ActionButton)(({ theme }) => ({
+  borderRadius: "8px",
+  ":hover": {
+    backgroundColor: theme.custom.colors.lightGray1,
+  },
   svg: {
-    fill: theme.custom.colors.silverGrayDark,
+    fill: theme.custom.colors.darkGray1,
   },
 }))
 
@@ -304,22 +309,26 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
 
   return (
     <FeedbackRowContainer>
-      <FeedbackButton
-        variant="text"
-        size="small"
-        onClick={onFeedback("like")}
-        aria-label="Like"
-      >
-        {feedback === "like" ? <RiThumbUpFill /> : <RiThumbUpLine />}
-      </FeedbackButton>
-      <FeedbackButton
-        variant="text"
-        size="small"
-        onClick={onFeedback("dislike")}
-        aria-label="Dislike"
-      >
-        {feedback === "dislike" ? <RiThumbDownFill /> : <RiThumbDownLine />}
-      </FeedbackButton>
+      <Tooltip title="Like">
+        <FeedbackButton
+          variant="text"
+          size="small"
+          onClick={onFeedback("like")}
+          aria-label="Like"
+        >
+          {feedback === "like" ? <RiThumbUpFill /> : <RiThumbUpLine />}
+        </FeedbackButton>
+      </Tooltip>
+      <Tooltip title="Dislike">
+        <FeedbackButton
+          variant="text"
+          size="small"
+          onClick={onFeedback("dislike")}
+          aria-label="Dislike"
+        >
+          {feedback === "dislike" ? <RiThumbDownFill /> : <RiThumbDownLine />}
+        </FeedbackButton>
+      </Tooltip>
     </FeedbackRowContainer>
   )
 }

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -278,8 +278,8 @@ const FeedbackRowContainer = styled.div({
 
 const FeedbackButton = styled(ActionButton)(({ theme }) => ({
   borderRadius: "8px",
-  ":hover": {
-    backgroundColor: theme.custom.colors.lightGray1,
+  ":hover:not(:disabled)": {
+    backgroundColor: theme.custom.colors.lightGray2,
   },
   svg: {
     fill: theme.custom.colors.darkGray1,
@@ -309,22 +309,22 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
 
   return (
     <FeedbackRowContainer>
-      <Tooltip title="Like">
+      <Tooltip title="Good response">
         <FeedbackButton
           variant="text"
           size="small"
           onClick={onFeedback("like")}
-          aria-label="Like"
+          aria-label="Good response"
         >
           {feedback === "like" ? <RiThumbUpFill /> : <RiThumbUpLine />}
         </FeedbackButton>
       </Tooltip>
-      <Tooltip title="Dislike">
+      <Tooltip title="Bad response">
         <FeedbackButton
           variant="text"
           size="small"
           onClick={onFeedback("dislike")}
-          aria-label="Dislike"
+          aria-label="Bad response"
         >
           {feedback === "dislike" ? <RiThumbDownFill /> : <RiThumbDownLine />}
         </FeedbackButton>

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -315,6 +315,7 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
           size="small"
           onClick={onFeedback("like")}
           aria-label="Good response"
+          aria-pressed={feedback === "like"}
         >
           {feedback === "like" ? <RiThumbUpFill /> : <RiThumbUpLine />}
         </FeedbackButton>
@@ -325,6 +326,7 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
           size="small"
           onClick={onFeedback("dislike")}
           aria-label="Bad response"
+          aria-pressed={feedback === "dislike"}
         >
           {feedback === "dislike" ? <RiThumbDownFill /> : <RiThumbDownLine />}
         </FeedbackButton>

--- a/src/components/AiChat/AiChatContext.stories.tsx
+++ b/src/components/AiChat/AiChatContext.stories.tsx
@@ -8,6 +8,8 @@ import { handlers } from "./test-utils/api"
 import Typography from "@mui/material/Typography"
 
 const TEST_API_STREAMING = "http://localhost:4567/streaming"
+const TEST_API_FEEDBACK =
+  "http://localhost:4567/feedback/:threadId/:checkpointPk"
 
 const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
   {
@@ -121,3 +123,18 @@ export default meta
 type Story = StoryObj<typeof AiChatProvider>
 
 export const StreamingResponses: Story = {}
+
+/**
+ * Here we provide the feedback API URL for the like/dislike buttons.
+ *
+ * The URL should include substitution strings for the `:threadId` and `:checkpointPk`,
+ * e.g. http://localhost:4567/feedback/:threadId/:checkpointPk
+ */
+export const JsonResponses: Story = {
+  args: {
+    requestOpts: {
+      apiUrl: TEST_API_STREAMING,
+      feedbackApiUrl: TEST_API_FEEDBACK,
+    },
+  },
+}

--- a/src/components/AiChat/AiChatContext.stories.tsx
+++ b/src/components/AiChat/AiChatContext.stories.tsx
@@ -24,8 +24,9 @@ const STARTERS = [
 
 const Container = styled.div({
   width: "100%",
-  height: "400px",
+  height: "700px",
   position: "relative",
+  fontFamily: "neue-haas-grotesk-text, sans-serif",
 })
 
 const MessageCounter = () => {
@@ -35,6 +36,31 @@ const MessageCounter = () => {
     <Typography variant="subtitle1">
       Message count: {messages.length} (Provided by <code>AiChatContext</code>)
     </Typography>
+  )
+}
+
+const LastMessageData = () => {
+  const { messages } = useAiChat()
+
+  const lastMessage = messages[messages.length - 1]
+
+  if (!lastMessage) return null
+
+  const { data } = lastMessage
+
+  if (!data) return null
+
+  return (
+    <>
+      <Typography variant="subtitle1">Last message data:</Typography>
+      <ul>
+        {Object.entries(data).map(([key, value]) => (
+          <li key={key}>
+            <strong>{key}</strong>: {value.toString()}
+          </li>
+        ))}
+      </ul>
+    </>
   )
 }
 
@@ -56,6 +82,7 @@ const meta: Meta<typeof AiChatProvider> = {
     return (
       <AiChatProvider {...args}>
         <MessageCounter />
+        <LastMessageData />
         <Container>
           <AiChatDisplay
             entryScreenEnabled={false}

--- a/src/components/AiChat/AiChatContext.stories.tsx
+++ b/src/components/AiChat/AiChatContext.stories.tsx
@@ -58,7 +58,7 @@ const LastMessageData = () => {
       <ul>
         {Object.entries(data).map(([key, value]) => (
           <li key={key}>
-            <strong>{key}</strong>: {value.toString()}
+            <strong>{key}</strong>: {value}
           </li>
         ))}
       </ul>
@@ -130,7 +130,7 @@ export const StreamingResponses: Story = {}
  * The URL should include substitution strings for the `:threadId` and `:checkpointPk`,
  * e.g. http://localhost:4567/feedback/:threadId/:checkpointPk
  */
-export const JsonResponses: Story = {
+export const FeedbackAPIUrl: Story = {
   args: {
     requestOpts: {
       apiUrl: TEST_API_STREAMING,

--- a/src/components/AiChat/AiChatContext.tsx
+++ b/src/components/AiChat/AiChatContext.tsx
@@ -131,7 +131,11 @@ const AiChatProvider: React.FC<AiChatContextProps> = ({
         return
       }
       const host = new URL(requestOpts.apiUrl).origin
-      const url = `${host}/ai/api/v0/chat_sessions/${data.thread_id}/messages/${data.checkpoint_pk}/rate/`
+      const url =
+        requestOpts.feedbackApiUrl
+          ?.replace(":threadId", data.thread_id)
+          .replace(":checkpointPk", data.checkpoint_pk) ||
+        `${host}/ai/api/v0/chat_sessions/${data.thread_id}/messages/${data.checkpoint_pk}/rate/`
       fetch(url, {
         method: "POST",
         headers: {
@@ -140,7 +144,7 @@ const AiChatProvider: React.FC<AiChatContextProps> = ({
         body: JSON.stringify({ rating }),
       })
     },
-    [requestOpts.apiUrl, messages],
+    [requestOpts.apiUrl, requestOpts.feedbackApiUrl, messages],
   )
 
   return (

--- a/src/components/AiChat/AiChatContext.tsx
+++ b/src/components/AiChat/AiChatContext.tsx
@@ -142,6 +142,7 @@ const AiChatProvider: React.FC<AiChatContextProps> = ({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ rating }),
+        credentials: "include",
       })
     },
     [requestOpts.apiUrl, requestOpts.feedbackApiUrl, messages],

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -315,14 +315,24 @@ const handlers = [
   }),
   http.post(
     "http://localhost:4567/ai/api/v0/chat_sessions/:threadId/messages/:checkpointPk/rate/",
-    async ({ params }) => {
-      return HttpResponse.json({ message: "Feedback received", ...params })
+    async ({ params, request }) => {
+      const body = await request.json()
+      return HttpResponse.json({
+        message: "Feedback received",
+        ...(body as Record<string, string>),
+        ...params,
+      })
     },
   ),
   http.post(
     "http://localhost:4567/feedback/:threadId/:checkpointPk",
-    async ({ params }) => {
-      return HttpResponse.json({ message: "Feedback received", ...params })
+    async ({ params, request }) => {
+      const body = await request.json()
+      return HttpResponse.json({
+        message: "Feedback received",
+        ...(body as Record<string, string>),
+        ...params,
+      })
     },
   ),
 ]

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -319,6 +319,12 @@ const handlers = [
       return HttpResponse.json({ message: "Feedback received" })
     },
   ),
+  http.post(
+    "http://localhost:4567/feedback/:threadId/:checkpointPk",
+    async ({ params }) => {
+      return HttpResponse.json({ message: "Feedback received", ...params })
+    },
+  ),
 ]
 
 export { handlers }

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -16,6 +16,8 @@ x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
 
 <!-- Comment! -->
+
+<!-- {"checkpoint_pk": 240, "thread_id": "d769e326d95248508d4abc8a8ad1696b"} -->
 `,
   `
 To understand global warming, I recommend the following resources from MIT:
@@ -35,6 +37,8 @@ x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
 
 <!-- Comment! -->
+
+<!-- {"checkpoint_pk": 241, "thread_id": "d769e326d95248508d4abc8a8ad1696b"} -->
 `,
   `
 Here are some courses on linear algebra that you can explore:
@@ -57,6 +61,8 @@ x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
 
 <!-- Comment! -->
+
+<!-- {"checkpoint_pk": 243, "thread_id": "d769e326d95248508d4abc8a8ad1696b"} -->
 `,
   `Here are some courses on quantum computing that offer certificates:
 
@@ -81,6 +87,8 @@ And some block math:
 $$
 x = \\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}
 $$
+
+<!-- {"checkpoint_pk": 244, "thread_id": "d769e326d95248508d4abc8a8ad1696b"} -->
 `,
   `Great question! Let's start by understanding what the problem is asking. You need to prove that the Adaptive Lasso is equivalent to a robust regression problem with a specific perturbation in the data matrix.
 
@@ -220,6 +228,8 @@ $$\\norm{\\vb{v}} \\quad \\text{norm}$$
 $$\\order{x^2} \\quad \\text{order notation}$$
 $$\\eval{f(x)}_{x=0} \\quad \\text{evaluated at}$$
 $$\\qty(\\frac{\\partial f}{\\partial x})_{y} \\quad \\text{quantity with subscript}$$
+
+<!-- {"checkpoint_pk": 245, "thread_id": "d769e326d95248508d4abc8a8ad1696b"} -->
 `,
 ]
 
@@ -303,6 +313,12 @@ const handlers = [
     await delay(800)
     return HttpResponse.json({ message })
   }),
+  http.post(
+    "http://localhost:4567/ai/api/v0/chat_sessions/:threadId/messages/:checkpointPk/rate/",
+    async () => {
+      return HttpResponse.json({ message: "Feedback received" })
+    },
+  ),
 ]
 
 export { handlers }

--- a/src/components/AiChat/test-utils/api.ts
+++ b/src/components/AiChat/test-utils/api.ts
@@ -315,8 +315,8 @@ const handlers = [
   }),
   http.post(
     "http://localhost:4567/ai/api/v0/chat_sessions/:threadId/messages/:checkpointPk/rate/",
-    async () => {
-      return HttpResponse.json({ message: "Feedback received" })
+    async ({ params }) => {
+      return HttpResponse.json({ message: "Feedback received", ...params })
     },
   ),
   http.post(

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -34,7 +34,7 @@ type RequestOpts = {
    * - :checkpointPk
    * e.g. "http://localhost:4567/feedback/:threadId/:checkpointPk"
    *
-   * If not provided, provided, defaults to the apiUrl origin + "/api/v0/chat_sessions/{thread_id}/messages/{checkpoint_pk}/rate/"
+   * If not provided, defaults to the apiUrl origin + "/api/v0/chat_sessions/{thread_id}/messages/{checkpoint_pk}/rate/"
    */
   feedbackApiUrl?: string
 

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -3,12 +3,18 @@
 import { RefAttributes } from "react"
 import type { MathJax3Config } from "better-react-mathjax"
 
-type Role = "assistant" | "user"
+type Role = "assistant" | "user" | "data" | "system"
+
+type MessageData = {
+  checkpoint_pk?: string
+  thread_id?: string
+}
 
 type AiChatMessage = {
   id: string
   content: string
   role: Role
+  data?: MessageData
 }
 
 type RequestOpts = {

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -25,6 +25,19 @@ type RequestOpts = {
    *
    * JSON.stringify is applied to the return value.
    */
+
+  /**
+   * URL for the like/dislike feedback endpoint.
+   *
+   * The URL should include the following substitution strings:
+   * - :threadId
+   * - :checkpointPk
+   * e.g. "http://localhost:4567/feedback/:threadId/:checkpointPk"
+   *
+   * If not provided, provided, defaults to the apiUrl origin + "/api/v0/chat_sessions/{thread_id}/messages/{checkpoint_pk}/rate/"
+   */
+  feedbackApiUrl?: string
+
   transformBody?: (
     messages: AiChatMessage[],
     body?: Record<string, string>,

--- a/src/components/AiChat/utils.ts
+++ b/src/components/AiChat/utils.ts
@@ -75,4 +75,38 @@ const useFetch = <T>(url: string | undefined) => {
   return { response, loading }
 }
 
-export { useAiChat, useFetch }
+/**
+ * Extracts comments from content and parses any that contain valid JSON.
+ */
+const extractCommentsData = (content: string): AiChatMessage["data"] => {
+  const commentRegex = /<!--\s*(.*?)\s*-->/g
+  const comments: string[] = []
+  let data = {}
+
+  let match
+  while ((match = commentRegex.exec(content)) !== null) {
+    comments.push(match[1].trim())
+  }
+
+  for (const comment of comments) {
+    try {
+      const parsed = JSON.parse(comment)
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        data = {
+          ...data,
+          ...parsed,
+        }
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return data
+}
+
+export { useAiChat, useFetch, extractCommentsData }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import styled from "@emotion/styled"
+import { default as MuiTooltip } from "@mui/material/Tooltip"
+import type { TooltipProps } from "@mui/material/Tooltip"
+
+const StyledTooltip = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.darkGray1,
+  padding: "4px 12px",
+  borderRadius: "12px",
+  marginTop: "4px",
+  ...theme.typography.body3,
+  color: theme.custom.colors.white,
+}))
+
+const Tooltip = ({ title, children, ...props }: TooltipProps) => {
+  return (
+    <MuiTooltip
+      title={title}
+      slots={{
+        tooltip: StyledTooltip,
+      }}
+      {...props}
+    >
+      {children}
+    </MuiTooltip>
+  )
+}
+
+export { Tooltip }
+export type { TooltipProps }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,9 @@ export {
   TabButtonList,
 } from "./components/TabButtons/TabButtonList"
 
+export { Tooltip } from "./components/Tooltip/Tooltip"
+export type { TooltipProps } from "./components/Tooltip/Tooltip"
+
 export { VERSION } from "./VERSION"
 
 export { VisuallyHidden } from "./components/VisuallyHidden/VisuallyHidden"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Frontend for https://github.com/mitodl/hq/issues/8382

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Adds like/dislike buttons for assistant responses.
- Extracts the `thread_id` and `checkpoint_pk` from comments in assistant responses (needed for the Learn AI feedback endpoint).
- Calls the Learn AI endpoint on feedback selection.
  - By default is the `apiUrl` origin and [`/ai/api/v0/chat_sessions/:threadId/messages/:checkpointPk/rate/`](https://github.com/mitodl/learn-ai/blob/main/openapi/specs/v0.yaml#L127).
  - A `feedbackApiUrl` prop is added to override this. Our use case is that for Open edX instances, the request needs to be forwarded via LMS/CMS endpoints provided by the plugin (new endpoint to be created alongside [ol_chat](https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/block.py#L274)).

### Screenshots (if appropriate):

<img width="992" height="514" alt="image" src="https://github.com/user-attachments/assets/b01c5b91-4d1e-41b1-8a1e-18b635a689f0" />
<br/>

<img width="166" height="77" alt="image" src="https://github.com/user-attachments/assets/90b4614c-3961-42e2-adb9-d037d61fb31c" />
<br/>
<img width="166" height="83" alt="image" src="https://github.com/user-attachments/assets/19549024-8be6-48d3-a6ce-f7f2a02850b5" />

<br/>
<img width="166" height="77" alt="image" src="https://github.com/user-attachments/assets/2f25a085-33ab-494d-8240-762da1105421" />
<br/>
<img width="166" height="70" alt="image" src="https://github.com/user-attachments/assets/95266661-1c9f-407a-ba06-023bf6520d8e" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start` for Storybook.
- Prompt for a response in any chat instance http://localhost:6006/?path=/docs/smoot-design-ai-aichat--docs.
- Check that the like/dislike buttons match the [designs in Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=25603-1602&m=dev).
- Check that the hover tooltips match the [designs in Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=25603-1603&m=dev).
- Hit the thumbs up or thumb down. Ensure the mock endpoint is called in the network tab. Ensure the respective rating is sent on the request body, `rating: "like"|"dislike"`.
- Clear a previous selection by toggling the button. Ensure the mock endpoint is called with `rating: ""`.
- The `feedbackApiUrl` is provided on the props in this story: http://localhost:6006/?path=/docs/smoot-design-ai-aichatcontext--docs#feedback-api-url. Check that the provided URL is used with message identifiers substituted in the path - http://localhost:4567/feedback/:threadId/:checkpointPk

### Additional context

- The change includes a known path on Learn API. As a frontend component library, Smoot Design should not know API specifics. Perhaps we should always provided the `feedbackApiUrl`, though would need to update all instances. If we do have API detail in the code, we should use the [API schema](https://github.com/mitodl/learn-ai/blob/main/openapi/specs/v0.yaml) client (is this published).



