### PR TITLE
feat: Updated the style of AskTim for slot

### DIFF
--- a/src/bundles/AiDrawer/AiDrawer.tsx
+++ b/src/bundles/AiDrawer/AiDrawer.tsx
@@ -102,25 +102,42 @@ const StyledTabPanel = styled(TabPanel)({
   position: "relative",
 })
 
-const StyledAiChat = styled(AiChat)<{ hasTabs: boolean }>(
-  ({ hasTabs, theme }) => ({
-    ".MitAiChat--entryScreenContainer": {
-      padding: hasTabs ? "114px 0 24px" : "168px 32px 24px",
-      [theme.breakpoints.down("md")]: {
-        padding: hasTabs ? "114px 0 24px" : "168px 16px 24px",
+const StyledAiChat = styled(AiChat)<{
+  hasTabs: boolean
+  variant: "drawer" | "slot"
+}>(({ hasTabs, variant, theme }) => ({
+  ".MitAiChat--entryScreenContainer": {
+    padding:
+      hasTabs && variant === "slot"
+        ? "24px 0 24px"
+        : hasTabs
+          ? "114px 0 24px"
+          : "168px 32px 24px",
+    ...(hasTabs && variant === "slot" && { justifyContent: "center" }),
+    [theme.breakpoints.down("md")]: {
+      padding:
+        hasTabs && variant === "slot"
+          ? "24px 0 24px"
+          : hasTabs
+            ? "114px 0 24px"
+            : "168px 16px 24px",
+    },
+  },
+  ".MitAiChat--chatScreenContainer": {
+    padding: hasTabs ? 0 : "0 32px",
+    [theme.breakpoints.down("md")]: {
+      padding: hasTabs ? 0 : "0 16px",
+    },
+  },
+  ".MitAiChat--messagesContainer": {
+    paddingTop: hasTabs ? "8px" : "88px",
+    ...(variant === "slot" && {
+      "> .MitAiChat--messageRowAssistant:first-child": {
+        marginTop: 0,
       },
-    },
-    ".MitAiChat--chatScreenContainer": {
-      padding: hasTabs ? 0 : "0 32px",
-      [theme.breakpoints.down("md")]: {
-        padding: hasTabs ? 0 : "0 16px",
-      },
-    },
-    ".MitAiChat--messagesContainer": {
-      paddingTop: hasTabs ? "8px" : "88px",
-    },
-  }),
-)
+    }),
+  },
+}))
 
 const StyledHTML = styled.div(({ theme }) => ({
   color: theme.custom.colors.darkGray2,
@@ -271,6 +288,7 @@ const ChatComponent = ({
   initialMessages,
   hasTabs,
   needsMathJax,
+  variant,
   onTrackingEvent,
 }: {
   settings: AiDrawerSettings["chat"]
@@ -283,6 +301,7 @@ const ChatComponent = ({
   initialMessages?: AiChatProps["initialMessages"]
   hasTabs: boolean
   needsMathJax: boolean
+  variant: "drawer" | "slot"
   onTrackingEvent?: TrackingEventHandler
 }) => {
   if (!settings) return null
@@ -311,6 +330,7 @@ const ChatComponent = ({
           }),
       }}
       hasTabs={hasTabs}
+      variant={variant}
       useMathJax={needsMathJax}
       onSubmit={(message, meta) => {
         onTrackingEvent?.({
@@ -460,6 +480,7 @@ const AiDrawer: FC<AiDrawerProps> = ({
           }
           hasTabs={hasTabs}
           needsMathJax={true}
+          variant={variant}
           onTrackingEvent={onTrackingEvent}
         />
       ) : null}
@@ -502,6 +523,7 @@ const AiDrawer: FC<AiDrawerProps> = ({
               initialMessages={chat.initialMessages}
               hasTabs={hasTabs}
               needsMathJax={false}
+              variant={variant}
               onTrackingEvent={onTrackingEvent}
             />
           </StyledTabPanel>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9143

### Description (What does it do?)
These changes are related to address the feedback given by Bilal. 

1- Remove the marging from **Hi! Do you need any help?** message appears at the start of the chat.
2- Adjust the top margin of video form and apply `justify-content: center` property so that user can see conversation starter cards aswell on 1440 screen resolution. 

### Screenshots (if appropriate):
<img width="1572" height="873" alt="Screenshot 2026-01-15 at 5 49 33 PM" src="https://github.com/user-attachments/assets/a2912c05-5db0-4c3c-a413-1e5f1d9b89f1" />
<img width="334" height="131" alt="Screenshot 2026-01-15 at 5 48 07 PM" src="https://github.com/user-attachments/assets/dad4956f-10e7-4a83-a2b3-b8ca16088bd7" />


### How can this be tested?
This will be tested along https://github.com/mitodl/ol-infrastructure/pull/4064

