### PR TITLE
feat: add an onClose optional param to Alert

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -61,6 +61,7 @@ type AlertProps = {
   closable?: boolean
   className?: string
   severity?: AlertColor
+  onClose?: (event?: React.SyntheticEvent) => void
   /**
    * Alert Content
    */
@@ -73,11 +74,13 @@ const Alert: React.FC<AlertProps> = ({
   closable,
   children,
   className,
+  onClose,
 }) => {
   const [_visible, setVisible] = React.useState(visible)
   const id = React.useId()
-  const onCloseClick = () => {
+  const onCloseClick = (event?: React.SyntheticEvent) => {
     setVisible(false)
+    onClose?.(event)
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/hq/issues/9851

### Description (What does it do?)
This PR adds an optional `onClose` argument to the `Alert` component, so you can fire an event when the alert is closed, passed from the parent component.

### How can this be tested?
Will be tested as part of https://github.com/mitodl/mit-learn/pull/2905
