### PR TITLE
feat: restyle-alerts

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -17,7 +17,7 @@ export const Basic: Story = {
     severity: "info",
   },
   render: (args) => (
-    <Alert {...args}>Alert with severity "{args.severity}"</Alert>
+    <Alert {...args}>Alert with severity "{args.severity}".</Alert>
   ),
 }
 
@@ -51,6 +51,16 @@ export const Variants: Story = {
       </Alert>
       <Alert {...args} closable severity="info">
         Closable alert with severity "info"
+      </Alert>
+      <Alert {...args} severity="info">
+        Multiline Alert <br />
+        Paullum deliquit, ponderibus modulisque suis ratio utitur. Quo usque
+        tandem abutere, Catilina, patientia nostra?
+      </Alert>
+      <Alert {...args} severity="info" closable>
+        Multiline Alert <br />
+        Paullum deliquit, ponderibus modulisque suis ratio utitur. Quo usque
+        tandem abutere, Catilina, patientia nostra?
       </Alert>
       <Alert {...args} severity="success">
         Alert with severity "success"

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -15,6 +15,7 @@ type Story = StoryObj<typeof Alert>
 export const Basic: Story = {
   args: {
     severity: "info",
+    label: "Optional Label",
   },
   render: (args) => (
     <Alert {...args}>Alert with severity "{args.severity}".</Alert>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -99,13 +99,7 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ theme, severity }) => {
   }
 })
 
-const SEVERITY_LABEL = {
-  info: "Information",
-  success: "Success",
-  warning: "Warning",
-  error: "Error",
-}
-const SeverityLabel = styled.span(({ theme }) => ({
+const ErrorLabel = styled.span(({ theme }) => ({
   ...theme.typography.subtitle2,
   marginRight: "8px",
 }))
@@ -129,6 +123,10 @@ type AlertProps = {
    * Alert Content
    */
   children?: React.ReactNode
+  /**
+   * An optional label to display before the alert content
+   */
+  label?: React.ReactNode
 }
 
 const Alert: React.FC<AlertProps> = ({
@@ -138,6 +136,7 @@ const Alert: React.FC<AlertProps> = ({
   children,
   className,
   onClose,
+  label,
 }) => {
   const [_visible, setVisible] = React.useState(visible)
   const id = React.useId()
@@ -175,7 +174,7 @@ const Alert: React.FC<AlertProps> = ({
         ) : null
       }
     >
-      <SeverityLabel>{SEVERITY_LABEL[severity]}</SeverityLabel>
+      {label ? <ErrorLabel>{label}</ErrorLabel> : null}
       {children}
       <Hidden id={id}>{severity} message</Hidden>
     </AlertStyled>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -4,30 +4,63 @@ import * as React from "react"
 
 import styled from "@emotion/styled"
 import { default as MuiAlert } from "@mui/material/Alert"
-import type { AlertColor } from "@mui/material/Alert"
+import type {
+  AlertProps as MuiAlertProps,
+  AlertColor,
+} from "@mui/material/Alert"
 import { Theme } from "@emotion/react"
+import {
+  RiInformation2Fill,
+  RiCheckboxCircleFill,
+  RiAlertFill,
+  RiErrorWarningFill,
+  RiCloseLine,
+} from "@remixicon/react"
+import { ActionButton } from "../Button/ActionButton"
+
+const withTransparency = (color: string, opacity: number) => {
+  return `color-mix(in srgb, ${color} ${opacity}%, transparent)`
+}
 
 const getColor = (theme: Theme, severity: AlertColor) => {
-  return {
-    info: theme.custom.colors.blue,
-    success: theme.custom.colors.green,
-    warning: theme.custom.colors.orange,
-    error: theme.custom.colors.lightRed,
-  }[severity]
+  const colors = {
+    info: {
+      borderColor: withTransparency(theme.custom.colors.blue, 50),
+      backgroundColor: withTransparency(theme.custom.colors.blue, 10),
+      iconFill: theme.custom.colors.blue,
+    },
+    warning: {
+      borderColor: withTransparency(theme.custom.colors.orange, 50),
+      backgroundColor: withTransparency(theme.custom.colors.orange, 15),
+      iconFill: theme.custom.colors.orange,
+    },
+    error: {
+      borderColor: withTransparency(theme.custom.colors.red, 15),
+      backgroundColor: withTransparency(theme.custom.colors.brightRed, 10),
+      iconFill: theme.custom.colors.red,
+    },
+    success: {
+      borderColor: withTransparency(theme.custom.colors.green, 20),
+      backgroundColor: withTransparency(theme.custom.colors.green, 4),
+      iconFill: theme.custom.colors.green,
+    },
+  }
+  return colors[severity]
 }
 
 type AlertStyleProps = {
   severity: AlertColor
 }
 
-const AlertStyled = styled(MuiAlert)<AlertStyleProps>(
-  ({ theme, severity }) => ({
+const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ theme, severity }) => {
+  const colors = getColor(theme, severity)
+  return {
     padding: "11px 16px",
     borderRadius: 4,
     borderWidth: 2,
     borderStyle: "solid",
-    borderColor: getColor(theme, severity),
-    background: "#FFF",
+    backgroundColor: colors.backgroundColor,
+    borderColor: colors.borderColor,
     ".MuiAlert-message": {
       ...theme.typography.body2,
       color: theme.custom.colors.darkGray2,
@@ -39,10 +72,28 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(
     },
     ".MuiAlert-icon": {
       marginRight: 8,
+      height: 0,
+      svg: {
+        width: 20,
+        height: 20,
+        fill: colors.iconFill,
+      },
+    },
+    ".MuiAlert-action": {
       svg: {
         width: 16,
-        fill: getColor(theme, severity),
+        height: 16,
+        stroke: theme.custom.colors.silverGrayDark,
       },
+      /**
+       * The close button is big enough that it would normally stretch the
+       * alert, at least for single-line alerts.
+       * We don't want to stretch the alert, but we do want to keep the button
+       * large enough to be easily clickable.
+       */
+      height: "20px",
+      display: "flex",
+      alignItems: "center",
     },
     button: {
       padding: 0,
@@ -51,8 +102,26 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(
         background: "none",
       },
     },
-  }),
-)
+  }
+})
+
+const SEVERITY_LABEL = {
+  info: "Information",
+  success: "Success",
+  warning: "Warning",
+  error: "Error",
+}
+const SeverityLabel = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  marginRight: "8px",
+}))
+
+const ICON_MAPPING: MuiAlertProps["iconMapping"] = {
+  info: <RiInformation2Fill />,
+  success: <RiCheckboxCircleFill />,
+  warning: <RiAlertFill />,
+  error: <RiErrorWarningFill />,
+}
 
 const Hidden = styled.span({ display: "none" })
 
@@ -98,7 +167,21 @@ const Alert: React.FC<AlertProps> = ({
       role="alert"
       aria-describedby={id}
       className={className}
+      iconMapping={ICON_MAPPING}
+      action={
+        closable ? (
+          <ActionButton
+            size="small"
+            variant="text"
+            aria-label="Dismiss"
+            onClick={onCloseClick}
+          >
+            <RiCloseLine />
+          </ActionButton>
+        ) : null
+      }
     >
+      <SeverityLabel>{SEVERITY_LABEL[severity]}</SeverityLabel>
       {children}
       <Hidden id={id}>{severity} message</Hidden>
     </AlertStyled>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -72,7 +72,6 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ theme, severity }) => {
     },
     ".MuiAlert-icon": {
       marginRight: 8,
-      height: 0,
       svg: {
         width: 20,
         height: 20,

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -95,13 +95,7 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ theme, severity }) => {
       display: "flex",
       alignItems: "center",
     },
-    button: {
-      padding: 0,
-      ":hover": {
-        margin: 0,
-        background: "none",
-      },
-    },
+    boxShadow: "0 4px 8px 0 rgba(19, 20, 21, 0.08)",
   }
 })
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10121

### Description (What does it do?)
Updates alert styling

### Screenshots (if appropriate):

<img width="1088" height="266" alt="Screenshot 2026-02-06 at 2 43 44 PM" src="https://github.com/user-attachments/assets/378abf0a-2200-45d9-9d20-284966f8c8d4" />
<img width="1098" height="810" alt="Screenshot 2026-02-06 at 2 43 40 PM" src="https://github.com/user-attachments/assets/4b6fccc6-1912-4f02-ad3b-f902a74f775f" />



### How can this be tested?
`yarn start` and view http://localhost:6006/?path=/docs/smoot-design-alert--docs; compare against https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=263-6634&m=dev

**Note:** The designs show "Information" / "Success" / "Warning" / "Error" labels. Based on usage elsewhere in Figma, this needs to be customizable and optional, e.g., 

- https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=26586-81898&m=dev
- https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=107-2479&p=f&m=dev