### PR TITLE
feat: Prevents flex items from being squished to try to fit

### DIFF
--- a/src/bundles/AiDrawer/AiDrawer.tsx
+++ b/src/bundles/AiDrawer/AiDrawer.tsx
@@ -113,7 +113,19 @@ const StyledAiChat = styled(AiChat)<{
         : hasTabs
           ? "114px 0 24px"
           : "168px 32px 24px",
-    ...(hasTabs && variant === "slot" && { justifyContent: "center" }),
+    ...(hasTabs &&
+      variant === "slot" && {
+        overflowY: "auto",
+        "> *": {
+          flexShrink: 0,
+        },
+        "> :first-child": {
+          marginTop: "auto",
+        },
+        "> :last-child": {
+          marginBottom: "auto",
+        },
+      }),
     [theme.breakpoints.down("md")]: {
       padding:
         hasTabs && variant === "slot"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9143#issuecomment-3914874969

### Description (What does it do?)
The EntryScreen container (which holds the AskTim icon, title, input, and suggested starter cards) uses `position: absolute; top: 0; bottom: 0 `to fill the tab panel. The old `justifyContent: "center" `caused content to overflow equally from top and bottom when the viewport height was reduced. This pushed the AskTim icon upward behind the sticky tabs, clipping it.



### Screenshots (if appropriate):
https://www.loom.com/share/9681c69f24a0463a80142f0410b272bd

<img width="1594" height="797" alt="Screenshot 2026-02-18 at 5 54 55 PM" src="https://github.com/user-attachments/assets/ac2e4209-284e-4b8f-a04d-b3d02045cb37" />
<img width="1512" height="811" alt="Screenshot 2026-02-18 at 5 55 16 PM" src="https://github.com/user-attachments/assets/36d39c34-5b80-476e-9388-52390f7b4665" />


### How can this be tested?
### How can this be tested?
To test this feature locally:

1. **Set up Tutor instance locally** as described in [this guide](https://docs.google.com/document/d/1kt_8VspC_SSU5zpmw8kyRQPWQaPtEbzTcDJeKYNBOfE/edit?tab=t.0)

2. **Mount frontend-app-learning locally**

3. **Enable AI Chatbot** by following the configuration steps in the [ol_openedx_chat plugin documentation](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)

4. **Build this branch** in the smoot-design repo by running:

The paths assume both directories are at the same level. If they're not siblings, adjust ../ as needed to navigate to the correct parent directory.

   ```bash
   cd smoot-design && yarn install && npm run build && npm pack && cp mitodl-smoot-design-*.tgz ../frontend-app-learning/ && cd ../frontend-app-learning && rm -rf package && tar -xvzf mitodl-smoot-design-*.tgz && mkdir -p public/static/smoot-design && cp package/dist/bundles/* public/static/smoot-design/
   ```
   ```bash
    cd ../frontend-app-learning && npm start
   ```

5. **Add AIDrawerManagerSidebar component and SidebarAIDrawerCoordinator**: Copy `AiDrawerManagerSidebar.jsx`  and `SidebarAIDrawerCoordinator` to the root of your local `frontend-app-learning` repository (alongside the `.env` file) from https://github.com/mitodl/ol-infrastructure/tree/main/src/bridge/settings/openedx/mfe/slot_config

6. **Update configuration**: Update `env.config.jsx` with the content from `learning-mfe-config.env.jsx` of repo https://github.com/mitodl/ol-infrastructure/.
7. Add ENABLE_AI_DRAWER_SLOT = 'true'  in .env.development file.
8. Update Bundle path with const BUNDLE_PATH =  '/static/smoot-design/aiDrawerManager.es.js';
9. Update your mitxonline-styles.scss file with the scss of the file in the https://github.com/mitodl/ol-infrastructure.

Now, on clicking the AskTim Button, it will open the AskTim Chat inside the Notifications/Discussions sidebar slot and when move to next Vertical, AskTim chat will close automatically. 
