### PR TITLE
feat: Display error message if AI response includes a hidden error message

### DIFF
--- a/src/components/AiChat/AiChat.test.tsx
+++ b/src/components/AiChat/AiChat.test.tsx
@@ -382,6 +382,31 @@ describe("AiChat", () => {
       }),
     )
   })
+
+  test("Displays a generic alert for hidden response errors instead of feedback controls", async () => {
+    setup()
+
+    server.use(
+      http.post(API_URL, async () => {
+        return HttpResponse.text(
+          '<!-- {"error":{"message":"An error occurred, please try again"},"checkpoint_pk":123,"thread_id":"f8a2b9c4e7d6f1a3b5c8e9d2f4a7b6c1"} -->',
+        )
+      }),
+    )
+
+    await user.click(getConversationStarters()[0])
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent(
+      "Sorry, an error occurred. Please try again.",
+    )
+    expect(
+      screen.queryByRole("button", { name: "Good response" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Bad response" }),
+    ).not.toBeInTheDocument()
+  })
 })
 
 test("replaceMathjax replaces unsupported MathJax syntax", () => {

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -290,6 +290,16 @@ const FeedbackButton = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
+const getMessageError = (message: AiChatMessage): boolean => {
+  const errorMessage = message.data?.error?.message
+
+  if (typeof errorMessage !== "string") {
+    return false
+  }
+
+  return errorMessage.trim().length > 0
+}
+
 const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
   const { submitFeedback } = useAiChat()
   const { t } = useTranslation()
@@ -308,7 +318,11 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
     [message.id, feedback, submitFeedback],
   )
 
-  if (!message.data?.checkpoint_pk || !message.data?.thread_id) {
+  if (
+    getMessageError(message) ||
+    !message.data?.checkpoint_pk ||
+    !message.data?.thread_id
+  ) {
     return null
   }
 
@@ -532,6 +546,9 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                 }}
               >
                 {messages.map((message: Message, index: number) => {
+                  const aiChatMessage = message as AiChatMessage
+                  const hasMessageError = getMessageError(aiChatMessage)
+
                   return (
                     <MessageRow
                       key={index}
@@ -550,10 +567,18 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                             ? t(TRANSLATION_KEYS.aiChat.srYouSaid)
                             : t(TRANSLATION_KEYS.aiChat.srAssistantSaid)}
                         </VisuallyHidden>
-                        <Markdown useMathJax={useMathJax}>
-                          {message.content}
-                        </Markdown>
-                        <FeedbackButtons message={message as AiChatMessage} />
+                        {message.role === "assistant" && hasMessageError ? (
+                          <Alert severity="error" closable>
+                            {t(TRANSLATION_KEYS.aiChat.errorHiddenResponse)}
+                          </Alert>
+                        ) : (
+                          <>
+                            <Markdown useMathJax={useMathJax}>
+                              {message.content}
+                            </Markdown>
+                            <FeedbackButtons message={aiChatMessage} />
+                          </>
+                        )}
                       </Message>
                     </MessageRow>
                   )

--- a/src/components/AiChat/AiChat.tsx
+++ b/src/components/AiChat/AiChat.tsx
@@ -290,7 +290,7 @@ const FeedbackButton = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
-const getMessageError = (message: AiChatMessage): boolean => {
+const hasMessageError = (message: AiChatMessage): boolean => {
   const errorMessage = message.data?.error?.message
 
   if (typeof errorMessage !== "string") {
@@ -319,7 +319,7 @@ const FeedbackButtons: FC<{ message: AiChatMessage }> = ({ message }) => {
   )
 
   if (
-    getMessageError(message) ||
+    hasMessageError(message) ||
     !message.data?.checkpoint_pk ||
     !message.data?.thread_id
   ) {
@@ -547,7 +547,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
               >
                 {messages.map((message: Message, index: number) => {
                   const aiChatMessage = message as AiChatMessage
-                  const hasMessageError = getMessageError(aiChatMessage)
+                  const hasError = hasMessageError(aiChatMessage)
 
                   return (
                     <MessageRow
@@ -567,7 +567,7 @@ const AiChatDisplay: FC<AiChatDisplayProps> = ({
                             ? t(TRANSLATION_KEYS.aiChat.srYouSaid)
                             : t(TRANSLATION_KEYS.aiChat.srAssistantSaid)}
                         </VisuallyHidden>
-                        {message.role === "assistant" && hasMessageError ? (
+                        {message.role === "assistant" && hasError ? (
                           <Alert severity="error" closable>
                             {t(TRANSLATION_KEYS.aiChat.errorHiddenResponse)}
                           </Alert>

--- a/src/components/AiChat/AiChatContext.stories.tsx
+++ b/src/components/AiChat/AiChatContext.stories.tsx
@@ -58,7 +58,7 @@ const LastMessageData = () => {
       <ul>
         {Object.entries(data).map(([key, value]) => (
           <li key={key}>
-            <strong>{key}</strong>: {value}
+            <strong>{key}</strong>: {JSON.stringify(value)}
           </li>
         ))}
       </ul>

--- a/src/components/AiChat/types.ts
+++ b/src/components/AiChat/types.ts
@@ -8,6 +8,9 @@ type Role = "assistant" | "user" | "data" | "system"
 type MessageData = {
   checkpoint_pk?: string
   thread_id?: string
+  error?: {
+    message?: string
+  }
 }
 
 type AiChatMessage = {

--- a/src/contexts/translationKeys.ts
+++ b/src/contexts/translationKeys.ts
@@ -21,6 +21,7 @@ export const TRANSLATION_KEYS = {
     srAssistantSaid: "aiChat.srAssistantSaid",
     noAssignmentsMessage: "aiChat.noAssignmentsMessage",
     errorGeneric: "aiChat.errorGeneric",
+    errorHiddenResponse: "aiChat.errorHiddenResponse",
     askQuestion: "aiChat.askQuestion",
     stop: "aiChat.stop",
     send: "aiChat.send",
@@ -65,6 +66,8 @@ export const DEFAULT_TRANSLATIONS: Record<TranslationKey, string> = {
   [TRANSLATION_KEYS.aiChat.noAssignmentsMessage]:
     "Hi! It looks like there are no assignments available right now. I'm here to help when there is an assignment ready to start.",
   [TRANSLATION_KEYS.aiChat.errorGeneric]: "An unexpected error has occurred.",
+  [TRANSLATION_KEYS.aiChat.errorHiddenResponse]:
+    "Sorry, an error occurred. Please try again.",
   [TRANSLATION_KEYS.aiChat.askQuestion]: "Ask a question",
   [TRANSLATION_KEYS.aiChat.stop]: "Stop",
   [TRANSLATION_KEYS.aiChat.send]: "Send",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10850
Closes https://github.com/mitodl/hq/issues/10840

### Description (What does it do?)
Displays a user-friendly error message, and hides thumbs-up/down buttons, if learn-ai responds with a hidden error message.

### Screenshots (if appropriate):

<img width="893" height="595" alt="Screenshot 2026-04-16 111624" src="https://github.com/user-attachments/assets/708aa4f3-5424-4627-9be0-de87fd73dd50" />


### How can this be tested?

#### learn-ai
-  Checkout commit `1c46a85fad89d5a6261b7a6b5701d47f64aa95e3`
- Set `LEARN_ACCESS_TOKEN` to the same value as on production in `backend.local.env`
- Assign other settings values as indicated in the learn-ai README, like `OPENAI_API_KEY` (can be the same as RC)
- `docker compose up`

#### mit-learn
- Check out the `mb/smoot-error-msg` branch (which installs this branch of smoot-design)
- Set this in your `frontend.local.env` file:
  ```
  NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://ai.open.odl.local:8005/http/recommendation_agent/
  NEXT_PUBLIC_LEARN_AI_LOGIN_ENDPOINT=http://ai.open.odl.local:8005/http/login/
  ```
- `docker compose up`  

- From the home page, open "AskTIM" and request "articles about climate change".  You should see an error message displayed, and no thumbs up/down buttons.
- Ask for "courses about climate change".  You should get some results, and there should be thumbs up/down buttons.
