### PR TITLE
fix: update h5 font weight

### DIFF
--- a/src/components/ThemeProvider/typography.ts
+++ b/src/components/ThemeProvider/typography.ts
@@ -60,7 +60,7 @@ const globalSettings: ThemeOptions["typography"] = {
   },
   h5: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: fontWeights.text.medium,
+    fontWeight: fontWeights.text.bold,
     fontStyle: "normal",
     fontSize: pxToRem(18),
     lineHeight: pxToRem(26),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/10977
<!--- N/A --->

### Description (What does it do?)
The h5 typography style in MIT Learn was using fontWeight: 500, which resolved to Neue Haas Grotesk Display Text 65 Medium. This was updated to font weight 700, which resolves to the 65 Bold variant. [Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=104-873&m=dev)

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
BEFORE 
<img width="1918" height="926" alt="before-storybook" src="https://github.com/user-attachments/assets/149b4a31-e786-413e-ae86-0aeb36f29c45" />


AFTER
<img width="1907" height="927" alt="after-storybook" src="https://github.com/user-attachments/assets/7fc94a8b-e4dd-4cb2-9b50-6a4c082a55bd" />

- [ ] Mobile width screenshots

### How can this be tested?
Using the browser's dev tools inspector, verify that the h5 element reflects a font-weight of 700.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
