### PR TITLE
feat: add the --Light-Gray-0 variable from Figma to the theme

### DIFF
--- a/src/components/ThemeProvider/colors.ts
+++ b/src/components/ThemeProvider/colors.ts
@@ -10,6 +10,7 @@ const colors = {
   silverGrayLight: "#B8C2CC",
   lightGray2: "#DDE1E6",
   lightGray1: "#F3F4F8",
+  lightGray0: "#F7F7F7",
   navGray: "#303337",
   darkPink: "#750062",
   pink: "#FF14F0",

--- a/src/type-augmentation/theme.d.ts
+++ b/src/type-augmentation/theme.d.ts
@@ -21,6 +21,7 @@ export interface CustomTheme {
     silverGrayLight: string
     lightGray2: string
     lightGray1: string
+    lightGray0: string
     navGray: string
     darkPink: string
     pink: string


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This PR simply adds the `lightGray0` var to the theme based on the `--Light-Gray-0` variable in Figma.

### How can this be tested?
- Run `yarn install && yarn build`
- Verify that `lightGray0` is now included in the theme
