### PR TITLE
fix: strip HTML comments from screen reader announcements in AiChat

### DIFF
--- a/src/components/AiChat/AiChat.stories.tsx
+++ b/src/components/AiChat/AiChat.stories.tsx
@@ -321,3 +321,66 @@ export const ScrollContainer: Story = {
 
   render: (args) => <ScrollComponent {...args} />,
 }
+
+/**
+ * This story verifies that HTML comments embedded in AI responses (used as a
+ * metadata side-channel) are stripped from the screen reader announcement.
+ *
+ * The dashed yellow box at the bottom of the chat shows the exact text that
+ * would be announced to screen reader users. It should NOT contain anything
+ * from the `<!-- ... -->` comment in the assistant message.
+ */
+export const ScreenReaderAnnouncementWithHtmlComments: Story = {
+  name: "Screen Reader: HTML Comments Stripped",
+  decorators: [
+    (Story) => (
+      <>
+        {/* eslint-disable-next-line react/no-danger */}
+        <style>{`
+          [aria-live] {
+            clip-path: none !important;
+            clip: auto !important;
+            height: auto !important;
+            overflow: visible !important;
+            position: static !important;
+            white-space: normal !important;
+            width: auto !important;
+            border: 2px dashed #e0a800 !important;
+            padding: 8px !important;
+            margin-top: 8px !important;
+            background: #fffde7 !important;
+            font-style: italic;
+            font-size: 0.875rem;
+          }
+        `}</style>
+        <p style={{ margin: "0 0 8px", fontSize: "0.875rem", color: "#555" }}>
+          The dashed yellow box below is the screen reader live region. It
+          should show the response text <strong>without</strong> the HTML
+          comment.
+        </p>
+        <Story />
+      </>
+    ),
+  ],
+  args: {
+    entryScreenEnabled: false,
+    conversationStarters: [],
+    initialMessages: [
+      {
+        role: "user",
+        content: "Explain the role of weather variables in wine pricing.",
+      },
+      {
+        role: "assistant",
+        content: `Weather variables play a crucial role as independent variables in the wine pricing model.
+
+1. **Temperature**: Higher average growing season temperatures lead to better grape quality and higher prices.
+2. **Rainfall**: Precipitation during the harvest season affects yield and concentration.
+
+Overall, weather variables provide a quantitative basis for predicting wine prices from empirical data.
+
+<!-- {"metadata": {"search_url": null}, "checkpoint_pk": 44302, "thread_id": "c58f04ccb91643bfa490bdc81e189738"} -->`,
+      },
+    ],
+  },
+}

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -60,7 +60,7 @@ describe("stripMarkdown", () => {
   })
 
   it("removes HTML comments", () => {
-    expect(stripMarkdown('text <!-- comment --> more text')).toBe(
+    expect(stripMarkdown("text <!-- comment --> more text")).toBe(
       "text  more text",
     )
     expect(

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -59,6 +59,18 @@ describe("stripMarkdown", () => {
     expect(result).toContain("code")
   })
 
+  it("removes HTML comments", () => {
+    expect(stripMarkdown('text <!-- comment --> more text')).toBe(
+      "text  more text",
+    )
+    expect(
+      stripMarkdown(
+        'Response text\n\n<!-- {"thread_id": "abc", "checkpoint_pk": 1} -->',
+      ),
+    ).toBe("Response text")
+    expect(stripMarkdown("<!-- multiline\ncomment -->text")).toBe("text")
+  })
+
   it("returns plain text unchanged", () => {
     expect(stripMarkdown("plain text with no markdown")).toBe(
       "plain text with no markdown",

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -2,9 +2,15 @@
  * Stripping markdown for screen reader announcements.
  * Not a full parser — handles the patterns common in LLM responses.
  */
-export const stripMarkdown = (text: string): string =>
-  text
-    .replace(/<!--[\s\S]*?-->/g, "")
+export const stripMarkdown = (text: string): string => {
+  let sanitized = text
+  let previous: string
+  do {
+    previous = sanitized
+    sanitized = sanitized.replace(/<!--[\s\S]*?-->/g, "")
+  } while (sanitized !== previous)
+
+  return sanitized
     .replace(/```[\s\S]*?```/g, "")
     .replace(/`([^`]+)`/g, "$1")
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
@@ -18,6 +24,7 @@ export const stripMarkdown = (text: string): string =>
     .replace(/^>\s+/gm, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim()
+}
 
 export const contentHash = (str: string) => {
   let hash = 5381

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -4,6 +4,7 @@
  */
 export const stripMarkdown = (text: string): string =>
   text
+    .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/```[\s\S]*?```/g, "")
     .replace(/`([^`]+)`/g, "$1")
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "")


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/11224
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

AskTim's AI responses include HTML comments as a metadata side-channel `(e.g. <!-- {"thread_id": "...", "checkpoint_pk": ...} -->).` These are invisible to sighted users because react-markdown renders with skipHtml={true}, but they were passing through stripMarkdown untouched and being read aloud verbatim by screen readers via the aria-live region.

Solution
Added a regex to stripMarkdown that removes HTML comments (`<!-- ... -->`, including multiline) before the rest of the markdown stripping runs. This mirrors what react-markdown already does visually.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

Storybook story BEFORE stripMarkdown that removes HTML comments
<img width="1904" height="950" alt="Screenshot 2026-05-13 at 3 19 28 PM" src="https://github.com/user-attachments/assets/654dce05-d2cb-4e81-a759-05ef4e342ea5" />


Storybook story AFTER stripMarkdown that removes HTML comments
<img width="1891" height="952" alt="Screenshot 2026-05-13 at 3 23 44 PM" src="https://github.com/user-attachments/assets/9f45abec-3846-4aeb-b5f4-1a511b39a6eb" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

**Automated**

- [ ]  Run npm test -- --testPathPattern=src/utils/string.test.ts and confirm all 13 tests pass, including the new "removes HTML comments" test

**Storybook (visual**)

- [ ]  Open smoot-design/AI/AiChat → Screen Reader: HTML Comments Stripped
- [ ]  Confirm a dashed yellow box is visible — this is the aria-live region made visible for inspection
- [ ]  Ask any question in the chat and wait for the response to finish streaming
- [ ]  Confirm the yellow box text contains only clean prose — no <!-- ... --> or {"thread_id"...} content

**Manual with a screen reader (VoiceOver on Mac)**

- [ ]  Open the AiChat story above with VoiceOver enabled
- [ ]  Ask a question and wait for the response to finish
- [ ]  Confirm VoiceOver announces the response text only — no HTML comment content is read aloud
- [ ]  Confirm bold/italic/headers are also still stripped (existing behavior unchanged)

**Regression**

- [ ] Open smoot-design/AI/AiChat → Streaming Responses, ask a question, and confirm the chat still works normally with no visual changes

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
