### PR TITLE
feat: enable math in video asktim

### DIFF
--- a/src/bundles/AiDrawer/AiDrawer.stories.tsx
+++ b/src/bundles/AiDrawer/AiDrawer.stories.tsx
@@ -101,6 +101,8 @@ export const EntryScreenStory: Story = {
 
 /**
  * The chat entry screen is shown by default for the video blocks Tutor drawer.
+ *
+ * The video chat renders math with MathJax, demonstrated by the initial message below.
  */
 export const VideoStory: Story = {
   args: {
@@ -109,6 +111,18 @@ export const VideoStory: Story = {
       chat: {
         apiUrl: TEST_API_STREAMING,
         conversationStarters: STARTERS,
+        initialMessages: [
+          {
+            role: "assistant",
+            content: `In the variable-angle random walk model, the mean-squared end-to-end distance of a polymer chain with $N$ monomers of length $l$ is:
+
+$$
+\\langle R^2 \\rangle = N l^2
+$$
+
+so the typical chain size scales as $\\sqrt{\\langle R^2 \\rangle} = l\\sqrt{N}$.`,
+          },
+        ],
       },
       summary: {
         apiUrl: CONTENT_FILE_URL,

--- a/src/bundles/AiDrawer/AiDrawer.tsx
+++ b/src/bundles/AiDrawer/AiDrawer.tsx
@@ -491,7 +491,7 @@ const AiDrawer: FC<AiDrawerProps> = ({
           <StyledTabButtonList
             styleVariant="chat"
             selectionFollowsFocus
-            onChange={(e, tab) => {
+            onChange={(_e, tab) => {
               setTab(tab)
               onTrackingEvent?.({
                 type: TrackingEventType.TabChange,
@@ -530,7 +530,7 @@ const AiDrawer: FC<AiDrawerProps> = ({
               conversationStarters={conversationStarters}
               initialMessages={chat.initialMessages}
               hasTabs={hasTabs}
-              needsMathJax={false}
+              needsMathJax={true}
               variant={variant}
               onTrackingEvent={onTrackingEvent}
             />
@@ -574,15 +574,17 @@ const AiDrawer: FC<AiDrawerProps> = ({
     <Drawer
       data-smoot-version={VERSION}
       className={className}
-      PaperProps={{
-        ref: paperRefCallback,
-        sx: {
-          width: "900px",
-          maxWidth: "100%",
-          boxSizing: "border-box",
-          padding: {
-            xs: "0 16px",
-            md: "0 32px",
+      slotProps={{
+        paper: {
+          ref: paperRefCallback,
+          sx: {
+            width: "900px",
+            maxWidth: "100%",
+            boxSizing: "border-box",
+            padding: {
+              xs: "0 16px",
+              md: "0 32px",
+            },
           },
         },
       }}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11746

### Description (What does it do?)
Enables MathJax for AskTim in Videos

### Screenshots (if appropriate):
<img width="1245" height="628" alt="Screenshot 2026-06-10 at 5 46 14 PM" src="https://github.com/user-attachments/assets/5f80a1dc-765f-453d-ba0d-01e460a79bc5" />


### How can this be tested?
1. `yarn start`
2. View video story at http://localhost:6006/?path=/docs/smoot-design-ai-aidrawer--docs
