### PR TITLE
feat: content feedback drawer bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:bundles": "vite build",
     "build:bundles:legacy": "vite build --config vite.config.legacy.mts",
     "build:bundles:aiChat": "vite build --config vite.config.aiChat.mts",
+    "build:bundles:feedback": "vite build --config vite.config.feedback.mts",
     "build:type-augmentation": "cp -r src/type-augmentation dist/type-augmentation",
     "build": "./scripts/build.sh",
     "lint-check": "eslint src/ .storybook/",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,4 +9,5 @@ rm -rf dist &&
 	npm run build:type-augmentation &&
 	npm run build:bundles &&
 	npm run build:bundles:legacy &&
-	npm run build:bundles:aiChat
+	npm run build:bundles:aiChat &&
+	npm run build:bundles:feedback

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
@@ -1,0 +1,121 @@
+import * as React from "react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { FeedbackDrawer } from "./FeedbackDrawer"
+import type { FeedbackData } from "./FeedbackDrawer"
+import Button from "@mui/material/Button"
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const logSubmit = async (data: FeedbackData) => {
+  // Stubbed submit — the manager layer will POST this to mit-learn.
+  // eslint-disable-next-line no-console
+  console.log("feedback submit", data)
+  await wait(700)
+}
+
+const failSubmit = async (data: FeedbackData) => {
+  // eslint-disable-next-line no-console
+  console.log("feedback submit (will fail)", data)
+  await wait(700)
+  throw new Error("stubbed failure")
+}
+
+const meta: Meta<typeof FeedbackDrawer> = {
+  title: "smoot-design/Feedback/FeedbackDrawer",
+  component: FeedbackDrawer,
+}
+
+export default meta
+
+type Story = StoryObj<typeof FeedbackDrawer>
+
+/**
+ * Default drawer: slides in from the right. Click the button to open it, then
+ * pick a reaction to reveal the matching prompt.
+ */
+export const DrawerStory: Story = {
+  name: "Drawer (slides in)",
+  render: () => {
+    const [open, setOpen] = React.useState(false)
+    return (
+      <>
+        <Button variant="outlined" onClick={() => setOpen(true)}>
+          Open feedback drawer
+        </Button>
+        <FeedbackDrawer
+          variant="drawer"
+          open={open}
+          onClose={() => setOpen(false)}
+          onSubmit={logSubmit}
+        />
+      </>
+    )
+  },
+}
+
+/**
+ * Slot variant: rendered inline (as it appears mounted in the Learning MFE
+ * sidebar region). Shown open so the full flow is visible at a glance.
+ */
+export const SlotStory: Story = {
+  name: "Slot (inline)",
+  render: () => (
+    <div
+      style={{
+        width: "420px",
+        maxWidth: "100%",
+        border: "1px solid #e3e6ea",
+        borderRadius: "12px",
+        boxShadow: "0 12px 30px rgba(0,0,0,0.10)",
+      }}
+    >
+      <FeedbackDrawer variant="slot" open onSubmit={logSubmit} />
+    </div>
+  ),
+}
+
+/**
+ * Slot variant opened with a reaction pre-selected, so the prompt + comment box
+ * + Submit are visible without interaction.
+ */
+export const SlotSelectedStory: Story = {
+  name: "Slot (reaction selected)",
+  render: () => (
+    <div
+      style={{
+        width: "420px",
+        maxWidth: "100%",
+        border: "1px solid #e3e6ea",
+        borderRadius: "12px",
+        boxShadow: "0 12px 30px rgba(0,0,0,0.10)",
+      }}
+    >
+      <FeedbackDrawer
+        variant="slot"
+        open
+        defaultSentiment="positive"
+        onSubmit={logSubmit}
+      />
+    </div>
+  ),
+}
+
+/**
+ * Same as Slot, but the stubbed submit rejects so the error state is visible.
+ */
+export const SlotErrorStory: Story = {
+  name: "Slot (submit error)",
+  render: () => (
+    <div
+      style={{
+        width: "420px",
+        maxWidth: "100%",
+        border: "1px solid #e3e6ea",
+        borderRadius: "12px",
+        boxShadow: "0 12px 30px rgba(0,0,0,0.10)",
+      }}
+    >
+      <FeedbackDrawer variant="slot" open onSubmit={failSubmit} />
+    </div>
+  ),
+}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react"
+import user from "@testing-library/user-event"
+import * as React from "react"
+import { FeedbackDrawer } from "./FeedbackDrawer"
+import { ThemeProvider } from "../../components/ThemeProvider/ThemeProvider"
+
+const renderDrawer = (props = {}) =>
+  render(<FeedbackDrawer variant="slot" open {...props} />, {
+    wrapper: ThemeProvider,
+  })
+
+describe("FeedbackDrawer", () => {
+  test("shows the question and three reactions", () => {
+    renderDrawer()
+    screen.getByText("How was this content?")
+    expect(screen.getAllByRole("radio")).toHaveLength(3)
+    screen.getByRole("radio", { name: "Liked it" })
+    screen.getByRole("radio", { name: "Not working" })
+    screen.getByRole("radio", { name: "Suggestion" })
+  })
+
+  test("selecting a reaction reveals its prompt, a comment box, and Submit", async () => {
+    renderDrawer()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    screen.getByText("What did you like?")
+    screen.getByRole("textbox", { name: "What did you like?" })
+    screen.getByRole("button", { name: "Submit" })
+  })
+
+  test("submitting calls onSubmit and shows the success state", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined)
+    renderDrawer({ onSubmit })
+    await user.click(screen.getByRole("radio", { name: "Suggestion" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What is your suggestion?" }),
+      "add captions",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+    expect(onSubmit).toHaveBeenCalledWith({
+      sentiment: "idea",
+      comment: "add captions",
+    })
+    await screen.findByText("Thank you for your feedback!")
+  })
+
+  test("shows the error state when onSubmit rejects", async () => {
+    const onSubmit = jest.fn().mockRejectedValue(new Error("boom"))
+    renderDrawer({ onSubmit })
+    await user.click(screen.getByRole("radio", { name: "Not working" }))
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+    await screen.findByText("Something went wrong. Please try again.")
+  })
+
+  test("arrow keys move selection across reactions (roving tabIndex)", async () => {
+    renderDrawer()
+    const [first, second] = screen.getAllByRole("radio")
+    // Before any selection, only the first radio is in the tab order.
+    expect(first).toHaveAttribute("tabindex", "0")
+    expect(second).toHaveAttribute("tabindex", "-1")
+
+    first.focus()
+    await user.keyboard("{ArrowRight}")
+
+    const negative = screen.getByRole("radio", { name: "Not working" })
+    expect(negative).toHaveAttribute("aria-checked", "true")
+    expect(negative).toHaveFocus()
+    expect(negative).toHaveAttribute("tabindex", "0")
+
+    // ArrowLeft back to the first, then ArrowLeft again wraps to the last.
+    await user.keyboard("{ArrowLeft}{ArrowLeft}")
+    const suggestion = screen.getByRole("radio", { name: "Suggestion" })
+    expect(suggestion).toHaveAttribute("aria-checked", "true")
+    expect(suggestion).toHaveFocus()
+  })
+
+  test("renders the subtitle (content title) under the heading", () => {
+    render(
+      <FeedbackDrawer variant="slot" open subtitle="Lecture 1: Limits" />,
+      { wrapper: ThemeProvider },
+    )
+    expect(screen.getByText("Lecture 1: Limits")).toBeVisible()
+  })
+})

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -1,0 +1,467 @@
+import * as React from "react"
+import { FC, useRef, useState } from "react"
+import styled from "@emotion/styled"
+import Drawer from "@mui/material/Drawer"
+import {
+  RiMegaphoneLine,
+  RiThumbUpLine,
+  RiThumbUpFill,
+  RiThumbDownLine,
+  RiThumbDownFill,
+  RiLightbulbLine,
+  RiLightbulbFill,
+  RiCloseLine,
+  RiCheckLine,
+} from "@remixicon/react"
+import type { RemixiconComponentType } from "@remixicon/react"
+import { ActionButton } from "../../components/Button/ActionButton"
+import { Button, ButtonLoadingIcon } from "../../components/Button/Button"
+import { Input } from "../../components/Input/Input"
+import { VERSION } from "../../VERSION"
+
+type Sentiment = "positive" | "negative" | "idea"
+
+type FeedbackData = {
+  sentiment: Sentiment
+  comment: string
+}
+
+type ReactionColorKey = "green" | "red" | "orange"
+
+type ReactionConfig = {
+  key: Sentiment
+  LineIcon: RemixiconComponentType
+  FillIcon: RemixiconComponentType
+  label: string
+  prompt: string
+  colorKey: ReactionColorKey
+  tintAlpha: number
+}
+
+const REACTIONS: ReactionConfig[] = [
+  {
+    key: "positive",
+    LineIcon: RiThumbUpLine,
+    FillIcon: RiThumbUpFill,
+    label: "Liked it",
+    prompt: "What did you like?",
+    colorKey: "green",
+    tintAlpha: 0.12,
+  },
+  {
+    key: "negative",
+    LineIcon: RiThumbDownLine,
+    FillIcon: RiThumbDownFill,
+    label: "Not working",
+    prompt: "What's not working?",
+    colorKey: "red",
+    tintAlpha: 0.1,
+  },
+  {
+    key: "idea",
+    LineIcon: RiLightbulbLine,
+    FillIcon: RiLightbulbFill,
+    label: "Suggestion",
+    prompt: "What is your suggestion?",
+    colorKey: "orange",
+    tintAlpha: 0.16,
+  },
+]
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const normalized = hex.replace("#", "")
+  const r = parseInt(normalized.slice(0, 2), 16)
+  const g = parseInt(normalized.slice(2, 4), 16)
+  const b = parseInt(normalized.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+const Container = styled.div(({ theme }) => ({
+  width: "100%",
+  display: "flex",
+  flexDirection: "column",
+  backgroundColor: theme.custom.colors.white,
+  boxSizing: "border-box",
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "0 32px 8px",
+  [theme.breakpoints.down("md")]: {
+    padding: "0 16px 8px",
+  },
+}))
+
+const Header = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: "4px",
+  position: "sticky",
+  top: 0,
+  padding: "32px 0 16px 0",
+  zIndex: 2,
+  backgroundColor: theme.custom.colors.white,
+}))
+
+const Title = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "8px",
+  flex: 1,
+  minWidth: 0,
+  color: theme.custom.colors.darkGray2,
+  svg: {
+    fill: theme.custom.colors.red,
+    width: "24px",
+    height: "24px",
+    flexShrink: 0,
+    marginTop: "2px",
+  },
+}))
+
+const CloseButton = styled(ActionButton)(({ theme }) => ({
+  backgroundColor: theme.custom.colors.lightGray2,
+  "&&:hover": {
+    backgroundColor: theme.custom.colors.red,
+    color: theme.custom.colors.white,
+  },
+  zIndex: 3,
+  flexShrink: 0,
+}))
+
+const Heading = styled.h1(({ theme }) => ({
+  ...theme.typography.body1,
+  flex: 1,
+  minWidth: 0,
+  margin: 0,
+  color: theme.custom.colors.darkGray2,
+  overflowWrap: "anywhere",
+}))
+
+const BlockName = styled.span(({ theme }) => ({
+  fontWeight: theme.typography.fontWeightBold,
+}))
+
+const Body = styled.div({
+  paddingBottom: "32px",
+})
+
+const Question = styled.h2(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  color: theme.custom.colors.darkGray2,
+  margin: "0 0 12px",
+}))
+
+const Reactions = styled.div({
+  display: "flex",
+  gap: "8px",
+  maxWidth: "360px",
+})
+
+const ReactionButton = styled.button<{
+  selected: boolean
+  colorKey: ReactionColorKey
+  tintAlpha: number
+}>(({ theme, selected, colorKey, tintAlpha }) => {
+  const accent = theme.custom.colors[colorKey]
+  return {
+    flex: 1,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "14px",
+    border: `1px solid ${selected ? accent : theme.custom.colors.lightGray2}`,
+    borderRadius: "8px",
+    background: selected
+      ? hexToRgba(accent, tintAlpha)
+      : theme.custom.colors.white,
+    color: accent,
+    cursor: "pointer",
+    transition: "border-color 120ms ease, background 120ms ease",
+    "&:hover": {
+      borderColor: accent,
+    },
+    "&:focus-visible": {
+      outline: `2px solid ${accent}`,
+      outlineOffset: "1px",
+    },
+    svg: {
+      width: "26px",
+      height: "26px",
+      fill: "currentColor",
+      display: "block",
+    },
+  }
+})
+
+const Prompt = styled.p(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.darkGray2,
+  margin: "20px 0 8px",
+}))
+
+const Footer = styled.div({
+  display: "flex",
+  justifyContent: "flex-end",
+  marginTop: "16px",
+})
+
+const ErrorText = styled.p(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.red,
+  margin: "10px 0 0",
+}))
+
+const Success = styled.div(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  color: theme.custom.colors.darkGreen,
+  padding: "8px 0",
+  svg: {
+    fill: theme.custom.colors.darkGreen,
+    width: "22px",
+    height: "22px",
+    flexShrink: 0,
+  },
+}))
+
+type SubmitStatus = "idle" | "submitting" | "success" | "error"
+
+type FeedbackDrawerProps = {
+  className?: string
+  /**
+   * Rendering variant:
+   * - "drawer" (default): MUI Drawer that slides in from the right.
+   * - "slot": plain container for placement inside a slot/sidebar.
+   */
+  variant?: "drawer" | "slot"
+  open?: boolean
+  onClose?: () => void
+  onSubmit?: (data: FeedbackData) => Promise<void> | void
+  /** Drawer heading. */
+  title?: string
+  /** Content title (block/unit) shown under the heading. */
+  subtitle?: string
+  defaultSentiment?: Sentiment
+}
+
+const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
+  className,
+  variant = "drawer",
+  open,
+  onClose,
+  onSubmit,
+  title = "Share your feedback",
+  subtitle,
+  defaultSentiment,
+}) => {
+  const [sentiment, setSentiment] = useState<Sentiment | null>(
+    defaultSentiment ?? null,
+  )
+  const [comment, setComment] = useState("")
+  const [status, setStatus] = useState<SubmitStatus>("idle")
+
+  const active =
+    REACTIONS.find((reaction) => reaction.key === sentiment) ?? null
+
+  const reactionRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const selectReaction = (key: Sentiment) => {
+    setSentiment(key)
+    setStatus("idle")
+  }
+
+  const focusableIndex = sentiment
+    ? REACTIONS.findIndex((reaction) => reaction.key === sentiment)
+    : 0
+
+  const handleReactionKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    let nextIndex: number | null = null
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIndex = (index + 1) % REACTIONS.length
+        break
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIndex = (index - 1 + REACTIONS.length) % REACTIONS.length
+        break
+      case "Home":
+        nextIndex = 0
+        break
+      case "End":
+        nextIndex = REACTIONS.length - 1
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    selectReaction(REACTIONS[nextIndex].key)
+    reactionRefs.current[nextIndex]?.focus()
+  }
+
+  const handleClose = () => {
+    onClose?.()
+  }
+
+  const handleSubmit = async () => {
+    if (!sentiment) {
+      return
+    }
+    setStatus("submitting")
+    try {
+      await onSubmit?.({ sentiment, comment })
+      setStatus("success")
+    } catch {
+      setStatus("error")
+    }
+  }
+
+  const content = (
+    <>
+      <Header>
+        <Title>
+          <RiMegaphoneLine aria-hidden />
+          <Heading>
+            {subtitle ? (
+              <>
+                {title} about <BlockName>{subtitle}</BlockName>
+              </>
+            ) : (
+              title
+            )}
+          </Heading>
+        </Title>
+        <CloseButton
+          variant="text"
+          size="medium"
+          onClick={handleClose}
+          aria-label="Close"
+        >
+          <RiCloseLine />
+        </CloseButton>
+      </Header>
+
+      <Body>
+        {status === "success" ? (
+          <Success>
+            <RiCheckLine aria-hidden /> Thank you for your feedback!
+          </Success>
+        ) : (
+          <>
+            <Question>How was this content?</Question>
+
+            <Reactions role="radiogroup" aria-label="How would you rate this?">
+              {REACTIONS.map((reaction, index) => {
+                const selected = reaction.key === sentiment
+                const Icon = selected ? reaction.FillIcon : reaction.LineIcon
+                return (
+                  <ReactionButton
+                    key={reaction.key}
+                    ref={(el) => {
+                      reactionRefs.current[index] = el
+                    }}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={reaction.label}
+                    title={reaction.label}
+                    tabIndex={index === focusableIndex ? 0 : -1}
+                    selected={selected}
+                    colorKey={reaction.colorKey}
+                    tintAlpha={reaction.tintAlpha}
+                    onClick={() => selectReaction(reaction.key)}
+                    onKeyDown={(event) => handleReactionKeyDown(event, index)}
+                  >
+                    <Icon />
+                  </ReactionButton>
+                )
+              })}
+            </Reactions>
+
+            {active ? (
+              <>
+                <Prompt>{active.prompt}</Prompt>
+                <Input
+                  multiline
+                  minRows={3}
+                  fullWidth
+                  value={comment}
+                  inputProps={{ maxLength: 1000, "aria-label": active.prompt }}
+                  onChange={(event) => setComment(event.target.value)}
+                />
+                {status === "error" ? (
+                  <ErrorText role="alert">
+                    Something went wrong. Please try again.
+                  </ErrorText>
+                ) : null}
+                <Footer>
+                  <Button
+                    variant="primary"
+                    size="medium"
+                    disabled={status === "submitting"}
+                    startIcon={
+                      status === "submitting" ? (
+                        <ButtonLoadingIcon />
+                      ) : undefined
+                    }
+                    onClick={handleSubmit}
+                  >
+                    Submit
+                  </Button>
+                </Footer>
+              </>
+            ) : null}
+          </>
+        )}
+      </Body>
+    </>
+  )
+
+  if (variant === "slot") {
+    if (!open) {
+      return null
+    }
+    return (
+      <Container className={className} data-smoot-version={VERSION}>
+        {content}
+      </Container>
+    )
+  }
+
+  return (
+    <Drawer
+      data-smoot-version={VERSION}
+      className={className}
+      anchor="right"
+      open={open}
+      onClose={handleClose}
+      role="dialog"
+      aria-modal="true"
+      keepMounted
+      PaperProps={{
+        sx: {
+          width: "420px",
+          maxWidth: "100%",
+          boxSizing: "border-box",
+          borderLeft: (theme) => `1px solid ${theme.custom.colors.lightGray2}`,
+          borderTopLeftRadius: "8px",
+          borderBottomLeftRadius: "8px",
+          padding: {
+            xs: "0 16px",
+            md: "0 32px",
+          },
+        },
+      }}
+    >
+      {content}
+    </Drawer>
+  )
+}
+
+export { FeedbackDrawer, REACTIONS }
+export type { FeedbackDrawerProps, FeedbackData, Sentiment }

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { FC, useRef, useState } from "react"
+import { FC, useEffect, useId, useRef, useState } from "react"
 import styled from "@emotion/styled"
 import Drawer from "@mui/material/Drawer"
 import {
@@ -266,6 +266,17 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     REACTIONS.find((reaction) => reaction.key === sentiment) ?? null
 
   const reactionRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const successRef = useRef<HTMLDivElement | null>(null)
+  const headingId = useId()
+
+  // Move focus to the success message so screen-reader users are told the
+  // submission succeeded (role="status" alone isn't reliably announced when the
+  // node is newly rendered).
+  useEffect(() => {
+    if (status === "success") {
+      successRef.current?.focus()
+    }
+  }, [status])
 
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
@@ -326,7 +337,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       <Header>
         <Title>
           <RiMegaphoneLine aria-hidden />
-          <Heading>
+          <Heading id={headingId}>
             {subtitle ? (
               <>
                 {title} about <BlockName>{subtitle}</BlockName>
@@ -336,19 +347,21 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
             )}
           </Heading>
         </Title>
-        <CloseButton
-          variant="text"
-          size="medium"
-          onClick={handleClose}
-          aria-label="Close"
-        >
-          <RiCloseLine />
-        </CloseButton>
+        {onClose ? (
+          <CloseButton
+            variant="text"
+            size="medium"
+            onClick={handleClose}
+            aria-label="Close"
+          >
+            <RiCloseLine />
+          </CloseButton>
+        ) : null}
       </Header>
 
       <Body>
         {status === "success" ? (
-          <Success>
+          <Success ref={successRef} role="status" tabIndex={-1}>
             <RiCheckLine aria-hidden /> Thank you for your feedback!
           </Success>
         ) : (
@@ -404,6 +417,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                     variant="primary"
                     size="medium"
                     disabled={status === "submitting"}
+                    aria-busy={status === "submitting"}
                     startIcon={
                       status === "submitting" ? (
                         <ButtonLoadingIcon />
@@ -442,6 +456,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       onClose={handleClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby={headingId}
       keepMounted
       PaperProps={{
         sx: {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -275,5 +275,4 @@ describe("FeedbackDrawerManager", () => {
     expect(headers["X-CSRFToken"]).toBeUndefined()
     await screen.findByText("Thank you for your feedback!")
   })
-
 })

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -1,0 +1,132 @@
+import { act, render, screen } from "@testing-library/react"
+import user from "@testing-library/user-event"
+import * as React from "react"
+import { FeedbackDrawerManager } from "./FeedbackDrawerManager"
+import { ThemeProvider } from "../../components/ThemeProvider/ThemeProvider"
+
+const ORIGIN = "http://localhost:6006"
+const SUBMIT_URL = "http://localhost:4567/feedback"
+
+const PAYLOAD = {
+  courseId: "course-v1:MITx+6.00+2024",
+  blockUsageKey: "block-v1:MITx+6.00+2024+type@video+block@abc",
+  blockType: "video",
+  blockDisplayName: "Lecture 1",
+}
+
+const openMessage = () =>
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: ORIGIN,
+        data: { type: "ol-feedback::drawer-open", payload: PAYLOAD },
+      }),
+    )
+  })
+
+describe("FeedbackDrawerManager", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test("renders a waiting marker until an open message arrives", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    screen.getByTestId("feedback-drawer-manager-waiting")
+    expect(screen.queryByText("How was this content?")).toBeNull()
+  })
+
+  test("ignores messages from a different origin", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "http://evil.example",
+          data: { type: "ol-feedback::drawer-open", payload: PAYLOAD },
+        }),
+      )
+    })
+    expect(screen.queryByText("How was this content?")).toBeNull()
+  })
+
+  test("opens the drawer and POSTs the mapped body on submit", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: true } as Response)
+    document.cookie = "csrftoken-test=tok123"
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfCookieName="csrftoken-test"
+        csrfHeaderName="X-CSRFToken"
+        getEnrichment={() => ({
+          courseName: "Intro to CS",
+          unitTitle: "Unit 3",
+          url: "http://localhost:6006/learning/x",
+        })}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    screen.getByText("How was this content?")
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [calledUrl, opts] = fetchMock.mock.calls[0]
+    const init = opts as RequestInit
+    const headers = init.headers as Record<string, string>
+    expect(calledUrl).toBe(SUBMIT_URL)
+    expect(init.method).toBe("POST")
+    expect(init.credentials).toBe("include")
+    expect(headers["Content-Type"]).toBe("application/json")
+    expect(headers["X-CSRFToken"]).toBe("tok123")
+    expect(JSON.parse(init.body as string)).toEqual({
+      course_id: PAYLOAD.courseId,
+      course_name: "Intro to CS",
+      block_usage_key: PAYLOAD.blockUsageKey,
+      block_type: PAYLOAD.blockType,
+      block_display_name: PAYLOAD.blockDisplayName,
+      unit_title: "Unit 3",
+      url: "http://localhost:6006/learning/x",
+      sentiment: "positive",
+      comment: "clear",
+    })
+    await screen.findByText("Thank you for your feedback!")
+  })
+
+  test("shows the block display name as the drawer subtitle", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    openMessage()
+    expect(screen.getByText(PAYLOAD.blockDisplayName)).toBeVisible()
+  })
+
+  test("clears the drawer on a close message", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    openMessage()
+    screen.getByText("How was this content?")
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ORIGIN,
+          data: { type: "ol-feedback::drawer-close" },
+        }),
+      )
+    })
+    expect(screen.queryByText("How was this content?")).toBeNull()
+    screen.getByTestId("feedback-drawer-manager-waiting")
+  })
+})

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -27,6 +27,14 @@ const openMessage = () =>
 describe("FeedbackDrawerManager", () => {
   afterEach(() => {
     jest.restoreAllMocks()
+    // jsdom persists document.cookie across tests; clear any set during a test
+    // so cookie state can't leak into later tests.
+    document.cookie.split(";").forEach((entry) => {
+      const name = entry.split("=")[0].trim()
+      if (name) {
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
+      }
+    })
   })
 
   test("renders a waiting marker until an open message arrives", () => {
@@ -129,4 +137,143 @@ describe("FeedbackDrawerManager", () => {
     expect(screen.queryByText("How was this content?")).toBeNull()
     screen.getByTestId("feedback-drawer-manager-waiting")
   })
+
+  test("primes the CSRF cookie when missing, then POSTs with the token", async () => {
+    const PRIME_URL = "http://localhost:4567/users/me"
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url === PRIME_URL) {
+        document.cookie = "csrftoken-prime=primedtok"
+        return Promise.resolve({ ok: true } as Response)
+      }
+      return Promise.resolve({ ok: true } as Response)
+    })
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfCookieName="csrftoken-prime"
+        csrfHeaderName="X-CSRFToken"
+        csrfPrimeUrl={PRIME_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(fetchMock.mock.calls[0][0]).toBe(PRIME_URL)
+    expect((fetchMock.mock.calls[0][1] as RequestInit).credentials).toBe(
+      "include",
+    )
+    const [postUrl, postInit] = fetchMock.mock.calls[1]
+    expect(postUrl).toBe(SUBMIT_URL)
+    expect(
+      (postInit as RequestInit).headers as Record<string, string>,
+    ).toMatchObject({ "X-CSRFToken": "primedtok" })
+  })
+
+  test("does not prime when the CSRF cookie is already present", async () => {
+    const PRIME_URL = "http://localhost:4567/users/me"
+    document.cookie = "csrftoken-present=already"
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: true } as Response)
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfCookieName="csrftoken-present"
+        csrfHeaderName="X-CSRFToken"
+        csrfPrimeUrl={PRIME_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe(SUBMIT_URL)
+  })
+
+  test("still submits if priming fails (best-effort)", async () => {
+    const PRIME_URL = "http://localhost:4567/users/me"
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url === PRIME_URL) {
+        return Promise.reject(new Error("network"))
+      }
+      return Promise.resolve({ ok: true } as Response)
+    })
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfCookieName="csrftoken-fail"
+        csrfHeaderName="X-CSRFToken"
+        csrfPrimeUrl={PRIME_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    const postCall = fetchMock.mock.calls.find((c) => c[0] === SUBMIT_URL)
+    expect(postCall).toBeTruthy()
+    await screen.findByText("Thank you for your feedback!")
+  })
+
+  test("submits without a CSRF header when priming does not set the cookie", async () => {
+    const PRIME_URL = "http://localhost:4567/users/me"
+    // Prime resolves OK but never sets the cookie (e.g. non-OK upstream or a
+    // response that doesn't carry Set-Cookie): the POST must still go out,
+    // just without the token header.
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: true } as Response)
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfCookieName="csrftoken-empty"
+        csrfHeaderName="X-CSRFToken"
+        csrfPrimeUrl={PRIME_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(fetchMock.mock.calls[0][0]).toBe(PRIME_URL)
+    const postCall = fetchMock.mock.calls.find((c) => c[0] === SUBMIT_URL)
+    expect(postCall).toBeTruthy()
+    const headers = (postCall![1] as RequestInit).headers as Record<
+      string,
+      string
+    >
+    expect(headers["X-CSRFToken"]).toBeUndefined()
+    await screen.findByText("Thank you for your feedback!")
+  })
+
 })

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -27,6 +27,8 @@ type FeedbackDrawerManagerProps = {
   submitUrl?: string
   csrfCookieName?: string
   csrfHeaderName?: string
+  /** mit-learn @ensure_csrf_cookie endpoint the drawer primes to obtain the CSRF cookie. */
+  csrfPrimeUrl?: string
   variant?: "drawer" | "slot"
   getEnrichment?: () => FeedbackEnrichment
 }
@@ -39,6 +41,7 @@ const FeedbackDrawerManager = ({
   submitUrl,
   csrfCookieName,
   csrfHeaderName,
+  csrfPrimeUrl,
   variant = "drawer",
   getEnrichment,
 }: FeedbackDrawerManagerProps) => {
@@ -107,12 +110,21 @@ const FeedbackDrawerManager = ({
     }
     const enrich = getEnrichment?.() ?? {}
 
-    // Same auth mechanism AskTIM (AiChat) uses: session cookie + read the CSRF
-    // token from a cookie and echo it in a header, with credentials included.
+    // Same auth mechanism AskTIM (AiChat) uses: session cookie + a CSRF token
+    // read from a cookie and echoed into a header, with credentials included.
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     }
     if (csrfCookieName && csrfHeaderName) {
+      // Feedback has no AskTIM-style consumer to set the CSRF cookie, so prime
+      // it (GET the @ensure_csrf_cookie endpoint) if it's missing.
+      if (csrfPrimeUrl && !getCookie(csrfCookieName)) {
+        try {
+          await fetch(csrfPrimeUrl, { credentials: "include" })
+        } catch {
+          // best-effort
+        }
+      }
       const csrfToken = getCookie(csrfCookieName)
       if (csrfToken) {
         headers[csrfHeaderName] = csrfToken

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -1,0 +1,161 @@
+import * as React from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { FeedbackDrawer } from "./FeedbackDrawer"
+import type { FeedbackData } from "./FeedbackDrawer"
+import { getCookie } from "../../utils/getCookie"
+
+type FeedbackPayload = {
+  courseId?: string
+  blockUsageKey?: string
+  blockType?: string
+  blockDisplayName?: string
+}
+
+type FeedbackOpenMessage = {
+  type: "ol-feedback::drawer-open"
+  payload: FeedbackPayload
+}
+
+type FeedbackEnrichment = {
+  courseName?: string
+  unitTitle?: string
+  url?: string
+}
+
+type FeedbackDrawerManagerProps = {
+  messageOrigin: string
+  submitUrl?: string
+  csrfCookieName?: string
+  csrfHeaderName?: string
+  variant?: "drawer" | "slot"
+  getEnrichment?: () => FeedbackEnrichment
+}
+
+const OPEN_MESSAGE = "ol-feedback::drawer-open"
+const CLOSE_MESSAGE = "ol-feedback::drawer-close"
+
+const FeedbackDrawerManager = ({
+  messageOrigin,
+  submitUrl,
+  csrfCookieName,
+  csrfHeaderName,
+  variant = "drawer",
+  getEnrichment,
+}: FeedbackDrawerManagerProps) => {
+  const [payload, setPayload] = useState<FeedbackPayload | null>(null)
+  const [open, setOpen] = useState(false)
+  // Bumped on every open so each open remounts FeedbackDrawer (resets state).
+  const [openSeq, setOpenSeq] = useState(0)
+  // Tracks the pending open-animation frame so a close can cancel it, otherwise
+  // a close arriving before the frame fires would be overridden by setOpen(true).
+  const openRafRef = useRef<number | null>(null)
+
+  const cancelPendingOpen = useCallback(() => {
+    if (openRafRef.current !== null) {
+      cancelAnimationFrame(openRafRef.current)
+      openRafRef.current = null
+    }
+  }, [])
+
+  // Keep the drawer mounted so MUI plays the slide-out; only slot mode tears down.
+  const handleClose = useCallback(() => {
+    cancelPendingOpen()
+    if (variant === "slot") {
+      setPayload(null)
+    }
+    setOpen(false)
+  }, [variant, cancelPendingOpen])
+
+  useEffect(() => {
+    const cb = (event: MessageEvent) => {
+      if (event.origin !== messageOrigin) {
+        return
+      }
+      const data = event.data as
+        | { type?: string; payload?: FeedbackPayload }
+        | undefined
+      if (data?.type === OPEN_MESSAGE) {
+        setPayload(data.payload || {})
+        setOpenSeq((seq) => seq + 1)
+        if (variant === "slot") {
+          setOpen(true)
+        } else {
+          setOpen(false)
+          cancelPendingOpen()
+          openRafRef.current = requestAnimationFrame(() => {
+            openRafRef.current = null
+            setOpen(true)
+          })
+        }
+      } else if (data?.type === CLOSE_MESSAGE) {
+        handleClose()
+      }
+    }
+    window.addEventListener("message", cb)
+    return () => window.removeEventListener("message", cb)
+  }, [messageOrigin, variant, handleClose, cancelPendingOpen])
+
+  useEffect(() => cancelPendingOpen, [cancelPendingOpen])
+
+  if (!payload) {
+    return <div data-testid="feedback-drawer-manager-waiting" />
+  }
+
+  const handleSubmit = async (data: FeedbackData) => {
+    if (!submitUrl) {
+      return // dev stub: no endpoint configured -> resolve to success
+    }
+    const enrich = getEnrichment?.() ?? {}
+
+    // Same auth mechanism AskTIM (AiChat) uses: session cookie + read the CSRF
+    // token from a cookie and echo it in a header, with credentials included.
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+    if (csrfCookieName && csrfHeaderName) {
+      const csrfToken = getCookie(csrfCookieName)
+      if (csrfToken) {
+        headers[csrfHeaderName] = csrfToken
+      }
+    }
+
+    const response = await fetch(submitUrl, {
+      method: "POST",
+      headers,
+      credentials: "include",
+      body: JSON.stringify({
+        course_id: payload.courseId,
+        course_name: enrich.courseName,
+        block_usage_key: payload.blockUsageKey,
+        block_type: payload.blockType,
+        block_display_name: payload.blockDisplayName,
+        unit_title: enrich.unitTitle,
+        url: enrich.url ?? window.location.href,
+        sentiment: data.sentiment,
+        comment: data.comment,
+      }),
+    })
+    if (!response.ok) {
+      throw new Error(`Feedback submit failed: ${response.status}`)
+    }
+  }
+
+  return (
+    <FeedbackDrawer
+      key={openSeq}
+      variant={variant}
+      open={open}
+      subtitle={payload.blockDisplayName}
+      onClose={handleClose}
+      onSubmit={handleSubmit}
+    />
+  )
+}
+
+export { FeedbackDrawerManager }
+export type {
+  FeedbackDrawerManagerProps,
+  FeedbackOpenMessage,
+  FeedbackPayload,
+  FeedbackEnrichment,
+}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -95,7 +95,12 @@ const FeedbackDrawerManager = ({
       }
     }
     window.addEventListener("message", cb)
-    return () => window.removeEventListener("message", cb)
+    return () => {
+      window.removeEventListener("message", cb)
+      // Cancel any pending open frame so a stale rAF can't call setOpen(true)
+      // after this effect re-runs (e.g. variant change) or the listener is torn down.
+      cancelPendingOpen()
+    }
   }, [messageOrigin, variant, handleClose, cancelPendingOpen])
 
   useEffect(() => cancelPendingOpen, [cancelPendingOpen])

--- a/src/bundles/feedbackDrawerManager.tsx
+++ b/src/bundles/feedbackDrawerManager.tsx
@@ -1,0 +1,142 @@
+import * as React from "react"
+import { createRoot } from "react-dom/client"
+import { FeedbackDrawerManager } from "./FeedbackDrawer/FeedbackDrawerManager"
+import type { FeedbackDrawerManagerProps } from "./FeedbackDrawer/FeedbackDrawerManager"
+import {
+  ThemeProvider,
+  createTheme,
+} from "../components/ThemeProvider/ThemeProvider"
+import { StyleIsolation } from "../components/StyleIsolation/StyleIsolation"
+import { TranslationProvider } from "../contexts/TranslationContext"
+import type { TranslationsInput } from "../contexts/TranslationContext"
+
+type InitOptions = {
+  container?: HTMLElement
+}
+
+/**
+ * Message-driven feedback drawer: the in-iframe megaphone posts an open message
+ * and the drawer renders as an overlay (`variant: "drawer"`) or inline in a
+ * host container (`variant: "slot"`).
+ */
+type FeedbackDrawerManagerInitOpts = FeedbackDrawerManagerProps & {
+  translations?: TranslationsInput | null
+}
+
+type InitReturn = {
+  unmount: () => void
+  container: HTMLElement
+}
+
+export type { InitOptions, InitReturn, FeedbackDrawerManagerInitOpts }
+
+const safeRemoveElement = (element: HTMLElement | null | undefined): void => {
+  if (!element?.parentNode) {
+    return
+  }
+  try {
+    element.parentNode.removeChild(element)
+  } catch {
+    // element/parent may already be gone in host DOM
+  }
+}
+
+const init = (
+  opts: FeedbackDrawerManagerInitOpts,
+  initOpts?: InitOptions,
+): InitReturn => {
+  const translations = opts.translations ?? null
+
+  const providedContainer = initOpts?.container
+  const isSlotVariant = opts.variant === "slot"
+  if (isSlotVariant && !providedContainer) {
+    throw new Error(
+      'Container is required for "slot" variant. Provide container in initOpts.',
+    )
+  }
+
+  const containerCreatedByInit = !providedContainer
+  let reactContainer: HTMLElement, container: HTMLElement
+
+  if (!providedContainer) {
+    container = document.createElement("div")
+    reactContainer = container
+    document.body.appendChild(container)
+  } else {
+    container = providedContainer
+    reactContainer = document.createElement("div")
+    reactContainer.style.width = "100%"
+    container.appendChild(reactContainer)
+  }
+
+  // Only stamp an id on containers we created; never mutate a caller-provided
+  // (slot) container's id.
+  if (containerCreatedByInit && !container.id) {
+    container.id = "smoot-feedback-drawer-root"
+  }
+
+  const isolationRoot = { element: null as HTMLElement | null }
+
+  const theme = createTheme({
+    components: {
+      MuiPopover: {
+        defaultProps: {
+          container: () => isolationRoot.element || reactContainer,
+        },
+      },
+      MuiPopper: {
+        defaultProps: {
+          container: () => isolationRoot.element || reactContainer,
+        },
+      },
+      MuiModal: {
+        defaultProps: {
+          container: () => isolationRoot.element || reactContainer,
+        },
+      },
+    },
+  })
+
+  const isolationRootRef = (element: HTMLDivElement | null) => {
+    isolationRoot.element = element
+  }
+
+  const { translations: _t, ...managerProps } = opts
+  const appNode = (
+    <FeedbackDrawerManager {...(managerProps as FeedbackDrawerManagerProps)} />
+  )
+
+  const root = createRoot(reactContainer)
+  root.render(
+    <StyleIsolation ref={isolationRootRef}>
+      <ThemeProvider theme={theme}>
+        <TranslationProvider translations={translations}>
+          {appNode}
+        </TranslationProvider>
+      </ThemeProvider>
+    </StyleIsolation>,
+  )
+
+  return {
+    unmount: () => {
+      try {
+        root.unmount()
+      } catch {
+        // root may already have been torn down
+      }
+      try {
+        if (reactContainer !== container) {
+          safeRemoveElement(reactContainer)
+        }
+        if (containerCreatedByInit) {
+          safeRemoveElement(container)
+        }
+      } catch {
+        // swallow cleanup errors
+      }
+    },
+    container,
+  }
+}
+
+export { init }

--- a/vite.config.feedback.mts
+++ b/vite.config.feedback.mts
@@ -1,0 +1,18 @@
+import path from "path"
+import { defineConfig } from "vite"
+
+export default defineConfig(({ mode }) => ({
+  build: {
+    outDir: "dist/bundles/",
+    emptyOutDir: false,
+    lib: {
+      entry: [path.resolve(__dirname, "src/bundles/feedbackDrawerManager.tsx")],
+      name: "feedbackDrawerManager",
+      fileName: (format) => `feedbackDrawerManager.${format}.js`,
+    },
+    sourcemap: true,
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify(mode),
+  },
+}))


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11814

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a reusable per-block **content feedback** UI + runtime bundle (`feedbackDrawerManager.es.js`) consumed by the Learning MFE. Feedback is submitted to **mit-learn**.

- `FeedbackDrawer` — shared drawer (`variant: 'drawer' | 'slot'`), three reactions with per-reaction prompts, a comment box, success/error states, and a `subtitle` that shows the content title under the heading.
- `FeedbackDrawerManager` — message-driven (`ol-feedback::drawer-open` / `::drawer-close`); maps the payload → snake_case POST body and merges a `getEnrichment()` result (`course_name`, `unit_title`, `url`). Powers both the overlay and the AskTIM-column-slot presentations. Submits using the **same auth mechanism AskTIM/AiChat uses**: `fetch(..., { credentials: "include" })`, reading the CSRF token from `csrfCookieName` and echoing it in `csrfHeaderName`. If that cookie is missing, it primes it first with a GET to `csrfPrimeUrl` (mit-learn `users/me`, `@ensure_csrf_cookie`) so a first-time submit doesn't 403.
- A single bundle entry exposes `init(opts, { container })`.

Backend submit is a no-op stub until `submitUrl` (`FEEDBACK_SUBMIT_URL`) is configured.

**Testing scope for this PR:** component behavior + the postMessage/submit contract — the drawer in isolation and the message/HTTP contract it exposes, without needing a live iframe host or the mit-learn endpoint (15 unit tests, all passing). Full **end-to-end** coverage — the live courseware megaphone trigger, slot mounting in `SidebarAIDrawerCoordinator`, sticky-height layout, mutual exclusivity with AskTIM/discussions, and persistence to the mit-learn `ContentFeedback` model — lands with the **lehrer integration PR**, where the host wiring exists to exercise it.

### Screenshots (if appropriate):
<img width="1482" height="908" alt="Screenshot 2026-07-21 at 6 39 06 PM" src="https://github.com/user-attachments/assets/40245692-4d84-46fa-9f49-e33c081710bf" />

<img width="1335" height="617" alt="Screenshot 2026-07-21 at 6 39 38 PM" src="https://github.com/user-attachments/assets/3f7bdd30-6584-4c1f-8e7a-cc2768bba229" />



### How can this be tested?

Component + contract only — no backend or iframe host needed.

```bash
yarn install
yarn jest src/bundles/FeedbackDrawer   # 15/15 pass
yarn typecheck                          # clean
```

**Visual (Storybook — needs Node ≥ 20.19 / 22.12):**
```bash
yarn start   # http://localhost:6006
```
Go to **Feedback → FeedbackDrawer** and walk the stories:
- **Drawer / Slot** — pick a reaction → its prompt + comment box + Submit appear → Submit shows "Thank you for your feedback!".
- **Slot (submit error)** — Submit → "Something went wrong. Please try again."
- Keyboard: Tab to a reaction, then `←`/`→`/`Home`/`End` move the selection.

Full E2E (courseware megaphone → slot mount → row persisted in mit-learn) is exercised in **lehrer [#83](https://github.com/mitodl/lehrer/pull/83)**.

**On RC / production:** this bundle is published to npm in `@mitodl/smoot-design` and served at `/learn/static/smoot-design/feedbackDrawerManager.es.js`. The Learning MFE loads it and supplies config (submit URL, CSRF cookie/header names) — wiring lives in **lehrer [#83](https://github.com/mitodl/lehrer/pull/83)**. No proxy in prod: the browser carries mit-learn's session/CSRF cookies directly (same-site over HTTPS, APISIX injects identity).

### Additional Context
<!--- optional - delete if empty --->
Full end-to-end validation (courseware trigger → slot mount → POST persisted in mit-learn) is intentionally deferred to the follow-up **lehrer integration PR**, which contains the host wiring needed to exercise it.


