### PR TITLE
fix: make Alert background and border opaque instead of transparent

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -84,3 +84,38 @@ export const Variants: Story = {
     </Stack>
   ),
 }
+
+export const OnDarkBackground: Story = {
+  argTypes: {
+    severity: {
+      table: {
+        disable: true,
+      },
+    },
+    closable: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: (args) => (
+    <Stack
+      direction="column"
+      gap={2}
+      sx={{ my: 2, p: 2, backgroundColor: "#212326" }}
+    >
+      <Alert {...args} severity="info">
+        Alert with severity "info"
+      </Alert>
+      <Alert {...args} severity="success">
+        Alert with severity "success"
+      </Alert>
+      <Alert {...args} severity="warning">
+        Alert with severity "warning"
+      </Alert>
+      <Alert {...args} severity="error">
+        Alert with severity "error"
+      </Alert>
+    </Stack>
+  ),
+}

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -18,30 +18,35 @@ import {
 } from "@remixicon/react"
 import { ActionButton } from "../Button/ActionButton"
 
-const withTransparency = (color: string, opacity: number) => {
-  return `color-mix(in srgb, ${color} ${opacity}%, transparent)`
+/**
+ * Mixes color with solid white so the result is opaque, rather than using
+ * CSS transparency, which would let whatever's behind the alert show
+ * through.
+ */
+const withOpaqueTint = (theme: Theme, color: string, opacity: number) => {
+  return `color-mix(in srgb, ${color} ${opacity}%, ${theme.custom.colors.white})`
 }
 
 const getColor = (theme: Theme, severity: AlertColor) => {
   const colors = {
     info: {
-      borderColor: withTransparency(theme.custom.colors.blue, 50),
-      backgroundColor: withTransparency(theme.custom.colors.blue, 10),
+      borderColor: withOpaqueTint(theme, theme.custom.colors.blue, 50),
+      backgroundColor: withOpaqueTint(theme, theme.custom.colors.blue, 10),
       iconFill: theme.custom.colors.blue,
     },
     warning: {
-      borderColor: withTransparency(theme.custom.colors.orange, 50),
-      backgroundColor: withTransparency(theme.custom.colors.orange, 15),
+      borderColor: withOpaqueTint(theme, theme.custom.colors.orange, 50),
+      backgroundColor: withOpaqueTint(theme, theme.custom.colors.orange, 15),
       iconFill: theme.custom.colors.orange,
     },
     error: {
-      borderColor: withTransparency(theme.custom.colors.red, 15),
-      backgroundColor: withTransparency(theme.custom.colors.brightRed, 10),
+      borderColor: withOpaqueTint(theme, theme.custom.colors.red, 15),
+      backgroundColor: withOpaqueTint(theme, theme.custom.colors.brightRed, 10),
       iconFill: theme.custom.colors.red,
     },
     success: {
-      borderColor: withTransparency(theme.custom.colors.green, 20),
-      backgroundColor: withTransparency(theme.custom.colors.green, 4),
+      borderColor: withOpaqueTint(theme, theme.custom.colors.green, 20),
+      backgroundColor: withOpaqueTint(theme, theme.custom.colors.green, 4),
       iconFill: theme.custom.colors.green,
     },
   }


### PR DESCRIPTION
### What are the relevant tickets?
N/A (follow-up to the styling introduced in #226 / mitodl/hq#10121)

### Description (What does it do?)
Alert background colors literally matched Figma, which uses a transparent background. This is not good for the Alert. They show up unreadable if the background happens to be dark. 

This change changes the background to a solid color. The solid color exactly matches the old background when the old background was white, which is the case on Figma and almost all of Learn. [One exception in Alert is an enrollment area in the header on product pages that is current nearly unreadable; another is an API error that can show up on staff-oriented news editing pages.]

### Screenshots (if appropriate):

<img width="1296" height="652" alt="before_after" src="https://github.com/user-attachments/assets/a1d3c80c-8bfb-4417-af2e-b81e2e9a9a8d" />


### How can this be tested?
`yarn start`, then open the Alert stories — a new `OnDarkBackground` story was added showing all four severities against a dark backdrop. Confirm the alert backgrounds/borders stay pale and legible rather than shifting dark.