### PR TITLE
feat: add autoHideDuration prop to Alert

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Alert } from "./Alert"
+import { Button } from "../Button/Button"
 import Stack from "@mui/material/Stack"
 
 const meta: Meta<typeof Alert> = {
@@ -83,6 +84,27 @@ export const Variants: Story = {
       </Alert>
     </Stack>
   ),
+}
+
+export const AutoHide: Story = {
+  args: {
+    severity: "success",
+    closable: true,
+    autoHideDuration: 5000,
+  },
+  render: (args) => {
+    const [visible, setVisible] = React.useState(false)
+    return (
+      <Stack direction="column" gap={2} alignItems="flex-start">
+        <Button onClick={() => setVisible(true)}>Show alert</Button>
+        {visible ? (
+          <Alert {...args} onClose={() => setVisible(false)}>
+            This alert will automatically hide after {args.autoHideDuration}ms.
+          </Alert>
+        ) : null}
+      </Stack>
+    )
+  },
 }
 
 export const OnDarkBackground: Story = {

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { act, render, screen } from "@testing-library/react"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
+import { Alert } from "./Alert"
+
+const renderAlert = (props: React.ComponentProps<typeof Alert>) =>
+  render(<Alert {...props} />, { wrapper: ThemeProvider })
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test("Stays visible without autoHideDuration", () => {
+  renderAlert({ children: "Message" })
+  act(() => {
+    jest.advanceTimersByTime(100_000)
+  })
+  expect(screen.getByRole("alert")).toBeInTheDocument()
+})
+
+test("Hides itself after autoHideDuration elapses", () => {
+  renderAlert({ children: "Message", autoHideDuration: 3000 })
+  expect(screen.getByRole("alert")).toBeInTheDocument()
+  act(() => {
+    jest.advanceTimersByTime(2999)
+  })
+  expect(screen.getByRole("alert")).toBeInTheDocument()
+  act(() => {
+    jest.advanceTimersByTime(1)
+  })
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+})
+
+test("Calls onClose when autoHideDuration elapses", () => {
+  const onClose = jest.fn()
+  renderAlert({ children: "Message", autoHideDuration: 3000, onClose })
+  act(() => {
+    jest.advanceTimersByTime(3000)
+  })
+  expect(onClose).toHaveBeenCalledTimes(1)
+})

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -131,6 +131,11 @@ type AlertProps = {
    * An optional label to display before the alert content
    */
   label?: React.ReactNode
+  /**
+   * If set, the alert will automatically hide itself after this many
+   * milliseconds. The timer resets whenever the alert becomes visible.
+   */
+  autoHideDuration?: number
 }
 
 const Alert: React.FC<AlertProps> = ({
@@ -141,6 +146,7 @@ const Alert: React.FC<AlertProps> = ({
   className,
   onClose,
   label,
+  autoHideDuration,
 }) => {
   const [_visible, setVisible] = React.useState(visible)
   const id = React.useId()
@@ -152,6 +158,19 @@ const Alert: React.FC<AlertProps> = ({
   React.useEffect(() => {
     setVisible(visible)
   }, [visible])
+
+  React.useEffect(() => {
+    if (!_visible || !autoHideDuration) {
+      return undefined
+    }
+    const timeoutId = setTimeout(() => {
+      setVisible(false)
+      onClose?.()
+    }, autoHideDuration)
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [_visible, autoHideDuration, onClose])
 
   if (!_visible) {
     return null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an `autoHideDuration` prop to `Alert`. When set (in milliseconds), the alert automatically dismisses itself after that duration and calls `onClose`, mirroring the semantics of MUI's `Snackbar.autoHideDuration`. The timer only runs while the alert is visible, resets if it becomes visible again, and is cleaned up on unmount/prop change. Without the prop, behavior is unchanged — alerts stay visible until manually closed.


### Screen Recording (if appropriate):
<!--- optional - delete if empty --->

https://github.com/user-attachments/assets/b3b7216f-56ee-494c-84d4-663a271b51a5



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Open `smoot-design/Alert` → `AutoHide` story
2. Click "Show alert" — the alert appears
3. Confirm it disappears on its own after `autoHideDuration` = 5000ms 

**Regression**
- [ ] Open the `Basic`, `Closable`, `Variants`, and `OnDarkBackground` stories and confirm they render and behave exactly as before (no `autoHideDuration` set → alerts stay visible until manually closed)

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
