### PR TITLE
fix: let Input grow to fit wrapping content (Autocomplete chip overflow)

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -4,6 +4,7 @@ import { Input, AdornmentButton } from "./Input"
 import type { InputProps } from "./Input"
 import Stack from "@mui/material/Stack"
 import Grid from "@mui/material/Grid"
+import Autocomplete from "@mui/material/Autocomplete"
 import { RiCalendarLine, RiCloseLine, RiSearchLine } from "@remixicon/react"
 import { fn } from "storybook/test"
 import { enumValues } from "../../story-utils"
@@ -84,7 +85,7 @@ type Story = StoryObj<typeof Input>
 export const Sizes: Story = {
   render: (args) => {
     return (
-      <Stack direction="row" gap={1}>
+      <Stack direction="row" gap={1} alignItems="flex-start">
         <StatefulInput size="small" {...args} />
         <StatefulInput size="medium" {...args} />
         <StatefulInput size="large" {...args} />
@@ -116,7 +117,7 @@ export const Adornments: Story = {
       },
     ]
     return (
-      <Grid container maxWidth="1400px" spacing={2}>
+      <Grid container maxWidth="1400px" spacing={2} alignItems="flex-start">
         {Object.values(adornments).flatMap((props, i) =>
           SIZES.map((size) => {
             return (
@@ -127,6 +128,54 @@ export const Adornments: Story = {
           }),
         )}
       </Grid>
+    )
+  },
+  argTypes: {
+    startAdornment: { table: { disable: true } },
+    endAdornment: { table: { disable: true } },
+  },
+}
+
+/**
+ * When `Input` hosts wrapping content — such as the selected-value chips of an
+ * `<Autocomplete multiple>` — the field grows to fit rather than clipping. Each
+ * size uses `min-height` (not a fixed `height`), so single-line inputs are
+ * unchanged while multi-row content makes the box taller.
+ */
+const TOPICS = [
+  "Mathematics",
+  "Physics",
+  "Chemistry",
+  "Biology",
+  "Computer Science",
+  "Economics",
+  "History",
+  "Philosophy",
+  "Linguistics",
+  "Engineering",
+]
+
+export const AutocompleteMultiple: Story = {
+  render: () => {
+    return (
+      <Stack direction="column" gap={2} maxWidth="400px">
+        {SIZES.map((size) => (
+          <Autocomplete
+            key={size}
+            multiple
+            options={TOPICS}
+            defaultValue={TOPICS.slice(0, 5)}
+            renderInput={(params) => (
+              <Input
+                {...params.InputProps}
+                inputProps={params.inputProps}
+                size={size}
+                placeholder="Topics"
+              />
+            )}
+          />
+        ))}
+      </Stack>
     )
   },
   argTypes: {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -69,19 +69,19 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
     },
     size === "small" &&
       !multiline && {
-        height: "32px",
+        minHeight: "32px",
       },
     size === "medium" &&
       !multiline && {
-        height: "40px",
+        minHeight: "40px",
       },
     size === "large" &&
       !multiline && {
-        height: "48px",
+        minHeight: "48px",
       },
     size === "chat" &&
       !multiline && {
-        height: "56px",
+        minHeight: "56px",
       },
     size === "chat" &&
       multiline && {
@@ -92,7 +92,7 @@ const sizeStyles = ({ size, theme, multiline }: SizeStyleProps) =>
       },
     size === "hero" &&
       !multiline && {
-        height: "72px",
+        minHeight: "72px",
       },
     size === "small" && {
       padding: "0 8px",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/4701

### Description (What does it do?)
<!--- Describe your changes in detail -->

mit-learn's learning-path form uses `<Autocomplete multiple>` for topics. Selected values render as chips inside the Input root, but `Input` set a fixed pixel `height` per size — so when chips wrapped to a second line they overflowed the box instead of the box growing. `multiline` isn't a viable workaround: it turns the field into a `<textarea>`, which MUI warns against inside Autocomplete.

- **`Input.tsx`** — in `sizeStyles`, convert each non-`multiline` height rule from `height` to `minHeight`
- **`Input.stories.tsx`** —
  - Add an `AutocompleteMultiple` story showing pre-selected chips wrapping and the field growing, at every size.
  - Pin the `Sizes` (`Stack`) and `Adornments` (`Grid`) showcase rows to `alignItems:

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

<img width="1077" height="565" alt="Screenshot 2026-07-24 at 11 29 32 AM" src="https://github.com/user-attachments/assets/04d18eb8-cb2b-49ac-9659-c8c963260bde" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. **AutocompleteMultiple** (new) — chips wrap and the field grows to fit at every size; add/remove chips and confirm smooth growth/shrink.
2. **Sizes** — each size renders at its intrinsic single-line height, vertically centered, no overflow (matches pre-change appearance).
3. **Adornments** — all sizes with start/end adornment buttons; buttons stay full-height and aligned as the field grows.
4. **Multiline** — unchanged (still `<textarea>`); confirm no regression.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
