### PR TITLE
feat: forward ref to root element in Alert

### DIFF
--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -35,6 +35,12 @@ test("Hides itself after autoHideDuration elapses", () => {
   expect(screen.queryByRole("alert")).not.toBeInTheDocument()
 })
 
+test("Forwards ref to the alert element", () => {
+  const ref = React.createRef<HTMLDivElement>()
+  render(<Alert ref={ref}>Message</Alert>, { wrapper: ThemeProvider })
+  expect(ref.current).toBe(screen.getByRole("alert"))
+})
+
 test("Calls onClose when autoHideDuration elapses", () => {
   const onClose = jest.fn()
   renderAlert({ children: "Message", autoHideDuration: 3000, onClose })

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -138,16 +138,19 @@ type AlertProps = {
   autoHideDuration?: number
 }
 
-const Alert: React.FC<AlertProps> = ({
-  visible = true,
-  severity = "info",
-  closable,
-  children,
-  className,
-  onClose,
-  label,
-  autoHideDuration,
-}) => {
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  {
+    visible = true,
+    severity = "info",
+    closable,
+    children,
+    className,
+    onClose,
+    label,
+    autoHideDuration,
+  },
+  ref,
+) {
   const [_visible, setVisible] = React.useState(visible)
   const id = React.useId()
   const onCloseClick = (event?: React.SyntheticEvent) => {
@@ -178,6 +181,7 @@ const Alert: React.FC<AlertProps> = ({
 
   return (
     <AlertStyled
+      ref={ref}
       severity={severity!}
       onClose={closable ? onCloseClick : undefined}
       role="alert"
@@ -202,7 +206,7 @@ const Alert: React.FC<AlertProps> = ({
       <Hidden id={id}>{severity} message</Hidden>
     </AlertStyled>
   )
-}
+})
 
 export { Alert }
 export type { AlertProps }


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Converts `Alert` from a plain function component to `React.forwardRef`, forwarding the ref through to the root element rendered by MUI's `Alert` (a `div`).

Previously `Alert` was typed `React.FC<AlertProps>` and silently dropped any `ref` passed to it, so consumers had no handle on the rendered element — nothing to measure, scroll into view, or focus.

Two notes on the implementation:

- **`React.forwardRef` rather than React 19's ref-as-prop**, because this package still supports React 18 through `peerDependencies` (`"react": "^18 || ^19"`). This also matches the existing pattern in `Button`, `ActionButton`, `ScrollSnap`, `LinkAdapter`, `ImageAdapter`, and `StyleIsolation`.
- **`Alert` returns `null` when it isn't visible** (dismissed, or after `autoHideDuration` elapses), so `ref.current` will be `null` in that state. That's the normal behaviour for a conditionally rendered element, but worth knowing if you're reading from the ref in an effect.

### How can this be tested?

Automated — a new case in `Alert.test.tsx` asserts the ref lands on the alert element:

```
yarn jest src/components/Alert
```

Full check, all green on this branch:

```
yarn jest        # 18 suites, 103 tests passed
yarn typecheck
yarn lint-check
```

Manual — render an `Alert` with a ref and confirm you get the root `div`:

```tsx
const ref = React.useRef<HTMLDivElement>(null)
React.useEffect(() => {
  console.log(ref.current) // <div role="alert" class="MuiAlert-root …">
}, [])
return <Alert ref={ref}>Something happened</Alert>
```

No visual change, so no screenshots — the rendered markup is identical apart from the ref attachment.

### Additional Context

While here I audited the rest of the package for components that swallow refs. Checked by asking TypeScript whether `"ref" extends keyof React.ComponentProps<typeof X>` for each.

Already fine — these accept and forward a ref today, either via explicit `forwardRef` or because they inherit MUI's prop types: `Input`, `SelectField`, `TabButtonList`, `Button`, `ButtonLink`, `ActionButton`, `ScrollSnap`, `LinkAdapter`, `ImageAdapter`, `StyleIsolation`.

Still swallowing refs, in rough priority order:

| Component | Why it might want one |
| --- | --- |
| `TextField` | Form libraries (e.g. `react-hook-form`'s `register`) need a ref to the input; focus-first-invalid-field needs it too |
| `Checkbox` | Same |
| `SimpleSelect` | Same |
| `RadioChoiceField` / `CheckboxChoiceField` | Focus management on validation error, though a group is a weaker case |
| `SrAnnouncer` | Probably doesn't need one |

Deliberately left out of this PR. `TextField` and friends are not a mechanical change like `Alert` was: they render a wrapper *and* an inner `<input>`, so "where does the ref go" is a real API decision (`react-hook-form` wants the `<input>`; measuring/scrolling wants the wrapper). Happy to open a follow-up issue if that's worth doing.
