### PR TITLE
feat: popup login + auto-submit for content feedback

### DIFF
--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -275,4 +275,139 @@ describe("FeedbackDrawerManager", () => {
     expect(headers["X-CSRFToken"]).toBeUndefined()
     await screen.findByText("Thank you for your feedback!")
   })
+
+  test("opens a login popup and auto-submits once a session is established", async () => {
+    const LOGIN_URL = "http://localhost:4567/login"
+    const PRIME_URL = "http://localhost:4567/users/me"
+    let meCalls = 0
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url === PRIME_URL) {
+        meCalls += 1
+        // open-time probe (call 1) is unauthenticated; once the popup logs in,
+        // the poll (call 2+) reports the session.
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ is_authenticated: meCalls > 1 }),
+        } as unknown as Response)
+      }
+      return Promise.resolve({ ok: true } as Response)
+    })
+    const close = jest.fn()
+    const openSpy = jest
+      .spyOn(window, "open")
+      .mockReturnValue({ closed: false, close } as unknown as Window)
+
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfPrimeUrl={PRIME_URL}
+        loginUrl={LOGIN_URL}
+        loginPollIntervalMs={5}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    // Let the open-time identity probe resolve (isAuthenticatedRef -> false).
+    await act(async () => {})
+
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    // window.open runs synchronously in the click gesture (popup-blocker safe).
+    expect(openSpy).toHaveBeenCalledWith(
+      LOGIN_URL,
+      "ol-feedback-login",
+      expect.stringContaining("popup"),
+    )
+    await screen.findByText("Thank you for your feedback!")
+    expect(close).toHaveBeenCalled()
+    const postCall = fetchMock.mock.calls.find((c) => c[0] === SUBMIT_URL)
+    expect(postCall).toBeTruthy()
+  })
+
+  test("submits directly without a popup when already authenticated", async () => {
+    const LOGIN_URL = "http://localhost:4567/login"
+    const PRIME_URL = "http://localhost:4567/users/me"
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url === PRIME_URL) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ is_authenticated: true }),
+        } as unknown as Response)
+      }
+      return Promise.resolve({ ok: true } as Response)
+    })
+    const openSpy = jest.spyOn(window, "open").mockReturnValue(null)
+
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfPrimeUrl={PRIME_URL}
+        loginUrl={LOGIN_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    // Let the open-time identity probe resolve (isAuthenticatedRef -> true).
+    await act(async () => {})
+
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(openSpy).not.toHaveBeenCalled()
+    const postCall = fetchMock.mock.calls.find((c) => c[0] === SUBMIT_URL)
+    expect(postCall).toBeTruthy()
+    await screen.findByText("Thank you for your feedback!")
+  })
+
+  test("surfaces an error when the login popup is blocked", async () => {
+    const LOGIN_URL = "http://localhost:4567/login"
+    const PRIME_URL = "http://localhost:4567/users/me"
+    jest.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url === PRIME_URL) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ is_authenticated: false }),
+        } as unknown as Response)
+      }
+      return Promise.resolve({ ok: true } as Response)
+    })
+    // A blocked popup returns null.
+    jest.spyOn(window, "open").mockReturnValue(null)
+
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+        csrfPrimeUrl={PRIME_URL}
+        loginUrl={LOGIN_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    // Let the open-time identity probe resolve (isAuthenticatedRef -> false).
+    await act(async () => {})
+
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+      "clear",
+    )
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+
+    await screen.findByText("Something went wrong. Please try again.")
+  })
 })

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -29,6 +29,18 @@ type FeedbackDrawerManagerProps = {
   csrfHeaderName?: string
   /** mit-learn @ensure_csrf_cookie endpoint the drawer primes to obtain the CSRF cookie. */
   csrfPrimeUrl?: string
+  /**
+   * mit-learn APISIX login route (e.g. `<mit-learn>/login`). When set, a learner
+   * with no mit-learn session is routed through a login popup before the POST, so
+   * their drafted feedback is preserved and auto-submitted once the session
+   * exists. Omit to disable the popup-login flow (the drawer then POSTs directly
+   * and surfaces any 403). Requires `csrfPrimeUrl` (the identity probe).
+   */
+  loginUrl?: string
+  /** Poll interval (ms) while waiting for the login popup to establish a session. */
+  loginPollIntervalMs?: number
+  /** Max time (ms) to wait for the login popup before giving up. */
+  loginTimeoutMs?: number
   variant?: "drawer" | "slot"
   getEnrichment?: () => FeedbackEnrichment
 }
@@ -42,6 +54,9 @@ const FeedbackDrawerManager = ({
   csrfCookieName,
   csrfHeaderName,
   csrfPrimeUrl,
+  loginUrl,
+  loginPollIntervalMs = 1000,
+  loginTimeoutMs = 30000,
   variant = "drawer",
   getEnrichment,
 }: FeedbackDrawerManagerProps) => {
@@ -105,13 +120,95 @@ const FeedbackDrawerManager = ({
 
   useEffect(() => cancelPendingOpen, [cancelPendingOpen])
 
+  // Whether the learner currently has a mit-learn session. null = unknown (not
+  // yet probed, or login not configured). Held in a ref so handleSubmit can read
+  // it synchronously and open the login popup within the click (popup-safe).
+  const isAuthenticatedRef = useRef<boolean | null>(null)
+
+  // GET the CSRF-prime endpoint (mit-learn users/me). Doubles as an identity
+  // probe: the JSON carries `is_authenticated`. Also (re)primes the CSRF cookie.
+  // Returns null when the state can't be determined.
+  const checkAuthenticated = useCallback(async (): Promise<boolean | null> => {
+    if (!csrfPrimeUrl) {
+      return null
+    }
+    try {
+      const res = await fetch(csrfPrimeUrl, { credentials: "include" })
+      if (!res.ok) {
+        return null
+      }
+      const body = (await res.json()) as { is_authenticated?: boolean }
+      return body?.is_authenticated === true
+    } catch {
+      return null
+    }
+  }, [csrfPrimeUrl])
+
+  // When login is configured, learn the session state as soon as the drawer
+  // opens — before the learner can click Submit — so the popup can be opened
+  // synchronously from that click without being blocked.
+  useEffect(() => {
+    if (!open || !loginUrl || !csrfPrimeUrl) {
+      return
+    }
+    let cancelled = false
+    checkAuthenticated().then((authed) => {
+      if (!cancelled && authed !== null) {
+        isAuthenticatedRef.current = authed
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [open, loginUrl, csrfPrimeUrl, checkAuthenticated])
+
   if (!payload) {
     return <div data-testid="feedback-drawer-manager-waiting" />
+  }
+
+  // Poll the identity probe until the login popup has established a mit-learn
+  // session (or the learner cancels / we time out). Closes the popup on success.
+  const waitForSession = async (popup: Window): Promise<void> => {
+    const deadline = Date.now() + loginTimeoutMs
+    for (;;) {
+      await new Promise((resolve) => setTimeout(resolve, loginPollIntervalMs))
+      const authed = await checkAuthenticated()
+      if (authed) {
+        isAuthenticatedRef.current = true
+        if (!popup.closed) {
+          popup.close()
+        }
+        return
+      }
+      if (popup.closed) {
+        throw new Error("Feedback login was cancelled")
+      }
+      if (Date.now() > deadline) {
+        popup.close()
+        throw new Error("Feedback login timed out")
+      }
+    }
   }
 
   const handleSubmit = async (data: FeedbackData) => {
     if (!submitUrl) {
       return // dev stub: no endpoint configured -> resolve to success
+    }
+    // When login is configured and the open-time probe found no mit-learn
+    // session, route the learner through a login popup before the POST so their
+    // drafted feedback is preserved and auto-submitted once the session exists.
+    // window.open must run synchronously in the click gesture (no await before
+    // it) or the browser's popup blocker kills it — hence the open-time probe.
+    if (loginUrl && isAuthenticatedRef.current === false) {
+      const popup = window.open(
+        loginUrl,
+        "ol-feedback-login",
+        "popup,width=480,height=680",
+      )
+      if (!popup) {
+        throw new Error("Feedback login popup was blocked")
+      }
+      await waitForSession(popup)
     }
     const enrich = getEnrichment?.() ?? {}
 
@@ -153,6 +250,11 @@ const FeedbackDrawerManager = ({
       }),
     })
     if (!response.ok) {
+      // A 403 means the POST was anonymous (no mit-learn session). Record that
+      // so a retry routes through the login popup; the learner's draft is kept.
+      if (response.status === 403) {
+        isAuthenticatedRef.current = false
+      }
       throw new Error(`Feedback submit failed: ${response.status}`)
     }
   }


### PR DESCRIPTION
### What are the relevant tickets?

- mitodl/hq#11629 (per-block content feedback)
- Follow-up to smoot-design #241 (feedback drawer bundle)

### Description (What does it do?)

Fixes the feedback-submit **403** for courseware-only learners.

A learner logged into courseware (`courses.<env>.learn.mit.edu`, an edxapp/Keycloak realm) but **not** into MIT Learn has no mit-learn/APISIX session. Their feedback `POST` arrives anonymous, so DRF `IsAuthenticated` returns **403 `NotAuthenticated`** before CSRF is ever checked. (Empirically: logged into `rc.learn.mit.edu` → 201; logged out → 403.)

This adds an optional **popup-login + auto-submit** flow to `FeedbackDrawerManager`:

- A new optional `loginUrl` prop (plus `loginPollIntervalMs` / `loginTimeoutMs`) enables the flow. **When `loginUrl` is unset the behavior is unchanged** — the drawer POSTs directly and surfaces any 403 — so existing consumers are unaffected.
- When `loginUrl` is set, the drawer **probes identity as it opens** (`GET csrfPrimeUrl` → `users/me`, reading `is_authenticated`). This is what makes the popup possible: the session state is known *before* the click.
- On Submit, if there is no session, the click handler **synchronously** opens a login popup (`window.open` must run in the gesture or popup blockers kill it), **polls** `users/me` until a session exists, closes the popup, then **auto-submits** the learner's already-drafted feedback. No retyping.
- As a fallback, a direct 403 flips the cached auth state to `false`, so a manual retry routes through the popup.

The auth/CSRF/submit pipeline stays entirely inside the smoot-design bundle (the generic, Appzi-replacement "engine" direction) — consumers only mount and pass config.

### Screenshots (if appropriate):

_n/a (behavioral). A flow diagram is attached as a PR comment._

### How can this be tested?

- `yarn jest src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx` — 12 tests, incl. three new ones: opens a popup and auto-submits once a session is established; submits directly when already authenticated; surfaces an error when the popup is blocked.
- `yarn typecheck` passes.
- Manual: with `loginUrl` set and no mit-learn session, click Submit → login popup → after logging in, the feedback auto-sends. With a session, it submits directly with no popup.

### Additional Context

Companion PR in **lehrer** wires the `FEEDBACK_LOGIN_URL` env var → `loginUrl` prop. Root cause and the two-gate (identity → CSRF) model are documented in the `content-feedback` skill (`references/auth-and-identity.md`).