### PR TITLE
feat: distinct rate-limit message on a 429 feedback response

### DIFF
--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
@@ -20,6 +20,15 @@ const failSubmit = async (data: FeedbackData) => {
   throw new Error("stubbed failure")
 }
 
+const rateLimitedSubmit = async (data: FeedbackData) => {
+  // eslint-disable-next-line no-console
+  console.log("feedback submit (will 429)", data)
+  await wait(700)
+  // Mirrors what FeedbackDrawerManager throws on a 429 response: the drawer
+  // reads `status` to show the throttle-specific copy.
+  throw Object.assign(new Error("throttled"), { status: 429 })
+}
+
 const meta: Meta<typeof FeedbackDrawer> = {
   title: "smoot-design/Feedback/FeedbackDrawer",
   component: FeedbackDrawer,
@@ -116,6 +125,27 @@ export const SlotErrorStory: Story = {
       }}
     >
       <FeedbackDrawer variant="slot" open onSubmit={failSubmit} />
+    </div>
+  ),
+}
+
+/**
+ * Same as Slot, but the stubbed submit rejects with a 429 so the rate-limit
+ * copy is visible (pick a reaction, then Submit).
+ */
+export const SlotRateLimitedStory: Story = {
+  name: "Slot (rate limited)",
+  render: () => (
+    <div
+      style={{
+        width: "420px",
+        maxWidth: "100%",
+        border: "1px solid #e3e6ea",
+        borderRadius: "12px",
+        boxShadow: "0 12px 30px rgba(0,0,0,0.10)",
+      }}
+    >
+      <FeedbackDrawer variant="slot" open onSubmit={rateLimitedSubmit} />
     </div>
   ),
 }

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import * as React from "react"
-import { FeedbackDrawer } from "./FeedbackDrawer"
+import {
+  FeedbackDrawer,
+  RATE_LIMIT_STATUS,
+  RATE_LIMIT_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+} from "./FeedbackDrawer"
 import { ThemeProvider } from "../../components/ThemeProvider/ThemeProvider"
 
 const renderDrawer = (props = {}) =>
@@ -48,7 +53,19 @@ describe("FeedbackDrawer", () => {
     renderDrawer({ onSubmit })
     await user.click(screen.getByRole("radio", { name: "Not working" }))
     await user.click(screen.getByRole("button", { name: "Submit" }))
-    await screen.findByText("Something went wrong. Please try again.")
+    await screen.findByText(GENERIC_ERROR_MESSAGE)
+  })
+
+  test("shows a rate-limit message when onSubmit rejects with a 429", async () => {
+    const onSubmit = jest
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("throttled"), { status: RATE_LIMIT_STATUS }),
+      )
+    renderDrawer({ onSubmit })
+    await user.click(screen.getByRole("radio", { name: "Not working" }))
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+    await screen.findByText(RATE_LIMIT_MESSAGE)
   })
 
   test("arrow keys move selection across reactions (roving tabIndex)", async () => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -19,6 +19,14 @@ import { Button, ButtonLoadingIcon } from "../../components/Button/Button"
 import { Input } from "../../components/Input/Input"
 import { VERSION } from "../../VERSION"
 
+// A 429 from the submit endpoint means the learner is being throttled; the
+// status and both error strings live here so the check + copy stay in one
+// place, are reusable in tests, and give us a single spot to localize later.
+const RATE_LIMIT_STATUS = 429
+const RATE_LIMIT_MESSAGE =
+  "You're sending feedback too quickly. Please wait a moment and try again."
+const GENERIC_ERROR_MESSAGE = "Something went wrong. Please try again."
+
 type Sentiment = "positive" | "negative" | "idea"
 
 type FeedbackData = {
@@ -261,6 +269,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   )
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
+  const [rateLimited, setRateLimited] = useState(false)
 
   const active =
     REACTIONS.find((reaction) => reaction.key === sentiment) ?? null
@@ -324,10 +333,14 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       return
     }
     setStatus("submitting")
+    setRateLimited(false)
     try {
       await onSubmit?.({ sentiment, comment })
       setStatus("success")
-    } catch {
+    } catch (error) {
+      setRateLimited(
+        (error as { status?: number })?.status === RATE_LIMIT_STATUS,
+      )
       setStatus("error")
     }
   }
@@ -409,7 +422,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                 />
                 {status === "error" ? (
                   <ErrorText role="alert">
-                    Something went wrong. Please try again.
+                    {rateLimited ? RATE_LIMIT_MESSAGE : GENERIC_ERROR_MESSAGE}
                   </ErrorText>
                 ) : null}
                 <Footer>
@@ -478,5 +491,11 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   )
 }
 
-export { FeedbackDrawer, REACTIONS }
+export {
+  FeedbackDrawer,
+  REACTIONS,
+  RATE_LIMIT_STATUS,
+  RATE_LIMIT_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+}
 export type { FeedbackDrawerProps, FeedbackData, Sentiment }

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import * as React from "react"
 import { FeedbackDrawerManager } from "./FeedbackDrawerManager"
+import { RATE_LIMIT_MESSAGE } from "./FeedbackDrawer"
 import { ThemeProvider } from "../../components/ThemeProvider/ThemeProvider"
 
 const ORIGIN = "http://localhost:6006"
@@ -236,6 +237,24 @@ describe("FeedbackDrawerManager", () => {
     const postCall = fetchMock.mock.calls.find((c) => c[0] === SUBMIT_URL)
     expect(postCall).toBeTruthy()
     await screen.findByText("Thank you for your feedback!")
+  })
+
+  test("shows the rate-limit message on a 429 response", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false, status: 429 } as Response)
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        submitUrl={SUBMIT_URL}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+    await screen.findByText(RATE_LIMIT_MESSAGE)
   })
 
   test("submits without a CSRF header when priming does not set the cookie", async () => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -153,7 +153,12 @@ const FeedbackDrawerManager = ({
       }),
     })
     if (!response.ok) {
-      throw new Error(`Feedback submit failed: ${response.status}`)
+      throw Object.assign(
+        new Error(`Feedback submit failed: ${response.status}`),
+        {
+          status: response.status,
+        },
+      )
     }
   }
 


### PR DESCRIPTION
### What are the relevant tickets?

- mitodl/hq#12355 (content_feedback submission throttle — backend)

### Description (What does it do?)

Shows a specific message when a feedback submit is rate-limited (**429**), instead of the generic error:

> You're sending feedback too quickly. Please wait a moment and try again.


### Screenshots (if appropriate):

<img width="739" height="475" alt="Screenshot 2026-08-03 at 3 58 07 PM" src="https://github.com/user-attachments/assets/04ff3084-7436-490e-9ac5-43ac8aab5ec4" />


### How can this be tested?

- **Storybook:** open the **"Slot (rate limited)"** story, pick a reaction, click **Submit** → the throttle message appears.
- **Unit:** `yarn jest src/bundles/FeedbackDrawer/` → 17 pass (incl. the drawer + manager 429 tests). `yarn typecheck` passes.

### Additional Context
Related backend pr:  https://github.com/mitodl/mit-learn/pull/3705
