### PR TITLE
fix: slate feedback drawer megaphone and full-width reaction row

### DIFF
--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -118,7 +118,7 @@ const Title = styled.div(({ theme }) => ({
   minWidth: 0,
   color: theme.custom.colors.darkGray2,
   svg: {
-    fill: theme.custom.colors.red,
+    fill: theme.custom.colors.silverGrayDark,
     width: "24px",
     height: "24px",
     flexShrink: 0,
@@ -162,7 +162,6 @@ const Question = styled.h2(({ theme }) => ({
 const Reactions = styled.div({
   display: "flex",
   gap: "8px",
-  maxWidth: "360px",
 })
 
 const ReactionButton = styled.button<{


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11629

### Description (What does it do?)

Two visual tweaks to the content feedback drawer:

- Recolours the header megaphone to slate (`silverGrayDark`) so it matches the restyled LMS trigger from mitodl/open-edx-plugins#839 instead of MIT red.
- Drops the 360px cap on the reaction row so the 👍 / 👎 / 💡 buttons stretch to fill the drawer width, removing the empty space after the idea button on wider slots.


### Screenshots (if appropriate):
<img width="1125" height="662" alt="Screenshot 2026-08-05 at 3 59 55 PM" src="https://github.com/user-attachments/assets/68ea49e2-173a-4360-ad03-f05ba286846a" />
### How can this be tested?

In Storybook:

1. `nvm use 24 && yarn install && yarn start` (Storybook serves on http://localhost:6006).
2. Open **smoot-design → Feedback → FeedbackDrawer**.
3. In **Slot (inline)** and **Slot (reaction selected)**: the header megaphone is slate (matching the trigger), and the 👍 / 👎 / 💡 buttons stretch across the full width with no trailing gap after the idea button.
4. In **Drawer (slides in)**: click "Open feedback drawer" and confirm the same in the slide-in variant.

### Additional Context

Companion trigger restyle: mitodl/open-edx-plugins#839