### PR TITLE
fix: manage keyboard focus for the inline feedback drawer

### DIFF
--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.stories.tsx
@@ -84,6 +84,33 @@ export const SlotStory: Story = {
 }
 
 /**
+ * Slot variant opened via keyboard, so the heading shows its focus ring. Mirrors
+ * a keyboard user activating the megaphone: FeedbackDrawerManager forwards the
+ * keyboard-open flag to the drawer as `openedViaKeyboard`.
+ */
+export const SlotKeyboardStory: Story = {
+  name: "Slot (keyboard open — focus ring)",
+  render: () => (
+    <div
+      style={{
+        width: "420px",
+        maxWidth: "100%",
+        border: "1px solid #e3e6ea",
+        borderRadius: "12px",
+        boxShadow: "0 12px 30px rgba(0,0,0,0.10)",
+      }}
+    >
+      <FeedbackDrawer
+        variant="slot"
+        open
+        openedViaKeyboard
+        onSubmit={logSubmit}
+      />
+    </div>
+  ),
+}
+
+/**
  * Slot variant opened with a reaction pre-selected, so the prompt + comment box
  * + Submit are visible without interaction.
  */

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -113,6 +113,20 @@ describe("FeedbackDrawer", () => {
     )
   })
 
+  test("marks the heading for a focus ring only when opened via keyboard", () => {
+    renderDrawer({ openedViaKeyboard: true })
+    expect(screen.getByRole("heading", { level: 1 })).toHaveAttribute(
+      "data-focus-ring",
+    )
+  })
+
+  test("omits the heading focus-ring marker when opened by mouse", () => {
+    renderDrawer({ openedViaKeyboard: false })
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveAttribute(
+      "data-focus-ring",
+    )
+  })
+
   test("exposes the open slot as a region labelled by its heading", () => {
     renderDrawer({ subtitle: "Lecture 1: Limits" })
     screen.getByRole("region", {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -24,12 +24,38 @@ describe("FeedbackDrawer", () => {
     screen.getByRole("radio", { name: "Suggestion" })
   })
 
+  test("names the reaction group with the visible question, not a mismatched label", () => {
+    renderDrawer()
+    // The group's accessible name is the on-screen "How was this content?"
+    // heading, so it matches what sighted users see (no stray "rate" wording).
+    screen.getByRole("radiogroup", { name: "How was this content?" })
+    expect(screen.queryByRole("radiogroup", { name: /rate/i })).toBeNull()
+  })
+
   test("selecting a reaction reveals its prompt, a comment box, and Submit", async () => {
     renderDrawer()
     await user.click(screen.getByRole("radio", { name: "Liked it" }))
     screen.getByText("What did you like?")
     screen.getByRole("textbox", { name: "What did you like?" })
     screen.getByRole("button", { name: "Submit" })
+  })
+
+  test("moves focus into the comment field when a reaction is clicked", async () => {
+    renderDrawer()
+    await user.click(screen.getByRole("radio", { name: "Not working" }))
+    expect(
+      screen.getByRole("textbox", { name: "What's not working?" }),
+    ).toHaveFocus()
+  })
+
+  test("moves focus into the comment field when a reaction is activated by keyboard", async () => {
+    renderDrawer()
+    const liked = screen.getByRole("radio", { name: "Liked it" })
+    liked.focus()
+    await user.keyboard("{Enter}")
+    expect(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+    ).toHaveFocus()
   })
 
   test("submitting calls onSubmit and shows the success state", async () => {
@@ -88,6 +114,19 @@ describe("FeedbackDrawer", () => {
     const suggestion = screen.getByRole("radio", { name: "Suggestion" })
     expect(suggestion).toHaveAttribute("aria-checked", "true")
     expect(suggestion).toHaveFocus()
+  })
+
+  test("arrow-key selection stays on the radios and doesn't jump to the comment box", async () => {
+    renderDrawer()
+    const [first] = screen.getAllByRole("radio")
+    first.focus()
+    await user.keyboard("{ArrowRight}")
+    // Arrowing reveals the comment field but keeps focus on the group so the
+    // user can keep comparing options; only an explicit activation moves focus.
+    expect(screen.getByRole("radio", { name: "Not working" })).toHaveFocus()
+    expect(
+      screen.getByRole("textbox", { name: "What's not working?" }),
+    ).not.toHaveFocus()
   })
 
   test("renders the subtitle (content title) under the heading", () => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import * as React from "react"
 import {
@@ -96,5 +96,39 @@ describe("FeedbackDrawer", () => {
       { wrapper: ThemeProvider },
     )
     expect(screen.getByText("Lecture 1: Limits")).toBeVisible()
+  })
+
+  test("moves focus to the heading when opened (slot variant)", async () => {
+    renderDrawer()
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1 })).toHaveFocus(),
+    )
+  })
+
+  test("makes the heading programmatically focusable", () => {
+    renderDrawer()
+    expect(screen.getByRole("heading", { level: 1 })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    )
+  })
+
+  test("exposes the open slot as a region labelled by its heading", () => {
+    renderDrawer({ subtitle: "Lecture 1: Limits" })
+    screen.getByRole("region", {
+      name: /share your feedback about lecture 1: limits/i,
+    })
+  })
+
+  test("closes when Escape is pressed inside the open slot", async () => {
+    const onClose = jest.fn()
+    renderDrawer({ onClose })
+    // Focus lands in the panel on open; Escape from anywhere inside should
+    // dismiss it (matching the dialog dismissal convention, WCAG 2.1.2).
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1 })).toHaveFocus(),
+    )
+    await user.keyboard("{Escape}")
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -60,9 +60,8 @@ describe("FeedbackDrawer", () => {
 
   test("previews the comment box for the first reaction when focus lands on it", () => {
     renderDrawer()
-    // Selection follows focus, so the first radio the Tab order lands on
-    // previews its prompt and comment box the same way the others do — the
-    // initial thumbs-up isn't a dead option that shows nothing.
+    // Selection follows focus, so the first radio previews its prompt and box
+    // like the others.
     const liked = screen.getByRole("radio", { name: "Liked it" })
     act(() => liked.focus())
     expect(liked).toHaveAttribute("aria-checked", "true")
@@ -132,8 +131,8 @@ describe("FeedbackDrawer", () => {
     const [first] = screen.getAllByRole("radio")
     act(() => first.focus())
     await user.keyboard("{ArrowRight}")
-    // Arrowing reveals the comment field but keeps focus on the group so the
-    // user can keep comparing options; only an explicit activation moves focus.
+    // Arrowing reveals the comment field but keeps focus on the radios; only
+    // activation moves focus.
     expect(screen.getByRole("radio", { name: "Not working" })).toHaveFocus()
     expect(
       screen.getByRole("textbox", { name: "What's not working?" }),

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import * as React from "react"
 import {
@@ -51,11 +51,22 @@ describe("FeedbackDrawer", () => {
   test("moves focus into the comment field when a reaction is activated by keyboard", async () => {
     renderDrawer()
     const liked = screen.getByRole("radio", { name: "Liked it" })
-    liked.focus()
+    act(() => liked.focus())
     await user.keyboard("{Enter}")
     expect(
       screen.getByRole("textbox", { name: "What did you like?" }),
     ).toHaveFocus()
+  })
+
+  test("previews the comment box for the first reaction when focus lands on it", () => {
+    renderDrawer()
+    // Selection follows focus, so the first radio the Tab order lands on
+    // previews its prompt and comment box the same way the others do — the
+    // initial thumbs-up isn't a dead option that shows nothing.
+    const liked = screen.getByRole("radio", { name: "Liked it" })
+    act(() => liked.focus())
+    expect(liked).toHaveAttribute("aria-checked", "true")
+    screen.getByRole("textbox", { name: "What did you like?" })
   })
 
   test("submitting calls onSubmit and shows the success state", async () => {
@@ -101,7 +112,7 @@ describe("FeedbackDrawer", () => {
     expect(first).toHaveAttribute("tabindex", "0")
     expect(second).toHaveAttribute("tabindex", "-1")
 
-    first.focus()
+    act(() => first.focus())
     await user.keyboard("{ArrowRight}")
 
     const negative = screen.getByRole("radio", { name: "Not working" })
@@ -119,7 +130,7 @@ describe("FeedbackDrawer", () => {
   test("arrow-key selection stays on the radios and doesn't jump to the comment box", async () => {
     renderDrawer()
     const [first] = screen.getAllByRole("radio")
-    first.focus()
+    act(() => first.focus())
     await user.keyboard("{ArrowRight}")
     // Arrowing reveals the comment field but keeps focus on the group so the
     // user can keep comparing options; only an explicit activation moves focus.
@@ -127,6 +138,26 @@ describe("FeedbackDrawer", () => {
     expect(
       screen.getByRole("textbox", { name: "What's not working?" }),
     ).not.toHaveFocus()
+  })
+
+  test("wraps Tab focus within the slot instead of escaping to the page", async () => {
+    renderDrawer({ onClose: jest.fn() })
+    // Reveal the comment box + Submit so the drawer has its full control set.
+    await user.click(screen.getByRole("radio", { name: "Liked it" }))
+
+    const close = screen.getByRole("button", { name: "Close" })
+    const submit = screen.getByRole("button", { name: "Submit" })
+
+    // Tab off the last control (Submit) wraps back to the first (Close) instead
+    // of walking out into the page footer.
+    act(() => submit.focus())
+    fireEvent.keyDown(submit, { key: "Tab" })
+    expect(close).toHaveFocus()
+
+    // Shift+Tab off the first control (Close) wraps to the last (Submit).
+    act(() => close.focus())
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true })
+    expect(submit).toHaveFocus()
   })
 
   test("renders the subtitle (content title) under the heading", () => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -19,9 +19,7 @@ import { Button, ButtonLoadingIcon } from "../../components/Button/Button"
 import { Input } from "../../components/Input/Input"
 import { VERSION } from "../../VERSION"
 
-// A 429 from the submit endpoint means the learner is being throttled; the
-// status and both error strings live here so the check + copy stay in one
-// place, are reusable in tests, and give us a single spot to localize later.
+// A 429 from the submit endpoint means the learner is being throttled.
 const RATE_LIMIT_STATUS = 429
 const RATE_LIMIT_MESSAGE =
   "You're sending feedback too quickly. Please wait a moment and try again."
@@ -143,13 +141,8 @@ const Heading = styled.h1(({ theme }) => ({
   margin: 0,
   color: theme.custom.colors.darkGray2,
   overflowWrap: "anywhere",
-  // The heading is focused programmatically on open, so kill the browser's
-  // native focus outline and drive the ring solely via data-focus-ring (set
-  // only for keyboard opens). Without outline:none the first mouse open still
-  // shows a ring — the megaphone click happens in the cross-origin LMS iframe,
-  // so the parent document has seen no pointer interaction and :focus-visible
-  // paints the native outline on programmatic focus. The opener signals
-  // modality to us instead. (WCAG 2.4.7)
+  // Focused programmatically on open, so suppress the native outline and drive
+  // the ring via data-focus-ring (keyboard opens only). (WCAG 2.4.7)
   outline: "none",
   "&[data-focus-ring]:focus": {
     outline: `2px solid ${theme.custom.colors.darkGray2}`,
@@ -285,8 +278,8 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
   const [rateLimited, setRateLimited] = useState(false)
-  // Monotonic counter bumped by commitReaction; the effect below keys on it (not
-  // on sentiment) so re-committing the same reaction still refocuses the comment.
+  // Bumped on each commit so re-committing the same reaction still refocuses the
+  // comment field.
   const [commitSeq, setCommitSeq] = useState(0)
 
   const active =
@@ -299,30 +292,24 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const headingId = useId()
   const questionId = useId()
 
-  // Move focus to the success message so screen-reader users are told the
-  // submission succeeded (role="status" alone isn't reliably announced when the
-  // node is newly rendered).
+  // Focus the success message so screen readers announce it (role="status"
+  // alone isn't reliably announced on a newly rendered node).
   useEffect(() => {
     if (status === "success") {
       successRef.current?.focus()
     }
   }, [status])
 
-  // When the panel opens as an inline slot, move focus to the heading so
-  // keyboard and screen-reader users are taken into the panel (and hear its
-  // title) rather than being left on the underlying course page. The overlay
-  // "drawer" variant is a MUI Modal, which manages its own focus on open.
+  // On slot open, focus the heading so keyboard/SR users are taken into the
+  // panel. The "drawer" variant is a MUI Modal and manages its own focus.
   useEffect(() => {
     if (open && variant === "slot") {
       headingRef.current?.focus()
     }
   }, [open, variant])
 
-  // The slot is a non-modal region (not a MUI Modal), so it doesn't get
-  // Escape-to-dismiss for free. Listen at the document level while open so
-  // keyboard users can close the panel with Escape, matching the dialog
-  // dismissal convention (WCAG 2.1.2). The overlay "drawer" variant is a MUI
-  // Modal and handles Escape itself.
+  // The slot is non-modal, so wire Escape-to-close ourselves (WCAG 2.1.2). The
+  // "drawer" variant is a MUI Modal and handles Escape itself.
   useEffect(() => {
     if (!open || variant !== "slot") {
       return
@@ -336,28 +323,23 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [open, variant, onClose])
 
-  // Move focus into the freshly revealed comment field so screen-reader users
-  // are taken to it (selecting a reaction otherwise gives no cue a text field
-  // appeared). The > 0 guard skips the initial defaultSentiment mount.
+  // Focus the revealed comment field on commit so SR users are taken to it. The
+  // > 0 guard skips the initial defaultSentiment mount.
   useEffect(() => {
     if (commitSeq > 0) {
       commentRef.current?.focus()
     }
   }, [commitSeq])
 
-  // Selection follows focus: focusing a reaction — whether the Tab order lands
-  // on it, arrow roving moves onto it, or a pointer presses it — selects it and
-  // reveals its comment prompt. This keeps every reaction consistent, so the
-  // first radio the Tab order lands on previews its field the same way the
-  // others do. It only roves selection; it never moves focus itself.
+  // Selection follows focus: focusing a reaction selects it and reveals its
+  // prompt, but never moves focus itself.
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
     setStatus("idle")
   }
 
-  // Pointer/Enter/Space activation commits the choice and (via the effect above)
-  // moves focus into the comment field. Focus alone (Tab or arrow roving) only
-  // previews via selectReaction and leaves focus on the radios.
+  // Activation (pointer/Enter/Space) commits and moves focus into the comment
+  // field; plain focus only previews via selectReaction.
   const commitReaction = (key: Sentiment) => {
     selectReaction(key)
     setCommitSeq((seq) => seq + 1)
@@ -416,10 +398,8 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     }
   }
 
-  // Keep keyboard focus inside the open slot: Tab past the last control wraps to
-  // the first, Shift+Tab past the first wraps to the last. The slot is a
-  // non-modal region, so without this the tab order spills into unrelated page
-  // chrome (e.g. the site footer) instead of staying with the feedback task.
+  // Keep Tab focus inside the non-modal slot: wrap Tab off the last control to
+  // the first, and Shift+Tab off the first to the last.
   const handleContainerKeyDown = (
     event: React.KeyboardEvent<HTMLDivElement>,
   ) => {
@@ -562,8 +542,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       return null
     }
     return (
-      // Focus-containment guard only (keeps Tab within the open drawer); the
-      // region itself isn't an interactive control.
+      // Focus-containment guard only; the region isn't an interactive control.
       // eslint-disable-next-line styled-components-a11y/no-noninteractive-element-interactions
       <Container
         className={className}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -143,9 +143,14 @@ const Heading = styled.h1(({ theme }) => ({
   margin: 0,
   color: theme.custom.colors.darkGray2,
   overflowWrap: "anywhere",
-  // Ring for keyboard opens only (data-focus-ring); a mouse open focuses the
-  // heading silently. Not :focus-visible — focus is programmatic across the
-  // iframe boundary, so the opener signals modality instead. (WCAG 2.4.7)
+  // The heading is focused programmatically on open, so kill the browser's
+  // native focus outline and drive the ring solely via data-focus-ring (set
+  // only for keyboard opens). Without outline:none the first mouse open still
+  // shows a ring — the megaphone click happens in the cross-origin LMS iframe,
+  // so the parent document has seen no pointer interaction and :focus-visible
+  // paints the native outline on programmatic focus. The opener signals
+  // modality to us instead. (WCAG 2.4.7)
+  outline: "none",
   "&[data-focus-ring]:focus": {
     outline: `2px solid ${theme.custom.colors.darkGray2}`,
     outlineOffset: "2px",

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -285,6 +285,10 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
   const [rateLimited, setRateLimited] = useState(false)
+  // Bumped whenever a reaction is committed (activated by pointer or
+  // Enter/Space) so an effect can move focus into the comment field that
+  // appears. Arrow-key roving doesn't bump it, so it doesn't move focus.
+  const [commitSeq, setCommitSeq] = useState(0)
 
   const active =
     REACTIONS.find((reaction) => reaction.key === sentiment) ?? null
@@ -292,7 +296,9 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const reactionRefs = useRef<(HTMLButtonElement | null)[]>([])
   const successRef = useRef<HTMLDivElement | null>(null)
   const headingRef = useRef<HTMLHeadingElement | null>(null)
+  const commentRef = useRef<HTMLTextAreaElement | null>(null)
   const headingId = useId()
+  const questionId = useId()
 
   // Move focus to the success message so screen-reader users are told the
   // submission succeeded (role="status" alone isn't reliably announced when the
@@ -331,9 +337,28 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [open, variant, onClose])
 
+  // After a reaction is committed (not while arrow-roving), move focus into the
+  // freshly revealed comment field so screen-reader users are taken to it;
+  // selecting a reaction otherwise gives no cue that a text field appeared.
+  // Keyed on commitSeq so re-activating the same reaction refocuses too; the
+  // > 0 guard keeps an initial defaultSentiment mount from stealing focus.
+  useEffect(() => {
+    if (commitSeq > 0) {
+      commentRef.current?.focus()
+    }
+  }, [commitSeq])
+
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
     setStatus("idle")
+  }
+
+  // Pointer/Enter/Space activation commits the choice and (via the effect above)
+  // moves focus into the comment field. Arrow keys call selectReaction directly,
+  // so they only rove selection within the group and leave focus on the radios.
+  const commitReaction = (key: Sentiment) => {
+    selectReaction(key)
+    setCommitSeq((seq) => seq + 1)
   }
 
   const focusableIndex = sentiment
@@ -428,9 +453,9 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
           </Success>
         ) : (
           <>
-            <Question>How was this content?</Question>
+            <Question id={questionId}>How was this content?</Question>
 
-            <Reactions role="radiogroup" aria-label="How would you rate this?">
+            <Reactions role="radiogroup" aria-labelledby={questionId}>
               {REACTIONS.map((reaction, index) => {
                 const selected = reaction.key === sentiment
                 const Icon = selected ? reaction.FillIcon : reaction.LineIcon
@@ -449,7 +474,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                     selected={selected}
                     colorKey={reaction.colorKey}
                     tintAlpha={reaction.tintAlpha}
-                    onClick={() => selectReaction(reaction.key)}
+                    onClick={() => commitReaction(reaction.key)}
                     onKeyDown={(event) => handleReactionKeyDown(event, index)}
                   >
                     <Icon />
@@ -465,6 +490,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                   multiline
                   minRows={3}
                   fullWidth
+                  inputRef={commentRef}
                   value={comment}
                   inputProps={{ maxLength: 1000, "aria-label": active.prompt }}
                   onChange={(event) => setComment(event.target.value)}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -143,6 +143,9 @@ const Heading = styled.h1(({ theme }) => ({
   margin: 0,
   color: theme.custom.colors.darkGray2,
   overflowWrap: "anywhere",
+  // The heading is focused programmatically on open (never via Tab), so the
+  // keyboard focus ring meant for tab navigation would be visual noise here.
+  "&:focus": { outline: "none" },
 }))
 
 const BlockName = styled.span(({ theme }) => ({
@@ -275,6 +278,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
 
   const reactionRefs = useRef<(HTMLButtonElement | null)[]>([])
   const successRef = useRef<HTMLDivElement | null>(null)
+  const headingRef = useRef<HTMLHeadingElement | null>(null)
   const headingId = useId()
 
   // Move focus to the success message so screen-reader users are told the
@@ -285,6 +289,34 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       successRef.current?.focus()
     }
   }, [status])
+
+  // When the panel opens as an inline slot, move focus to the heading so
+  // keyboard and screen-reader users are taken into the panel (and hear its
+  // title) rather than being left on the underlying course page. The overlay
+  // "drawer" variant is a MUI Modal, which manages its own focus on open.
+  useEffect(() => {
+    if (open && variant === "slot") {
+      headingRef.current?.focus()
+    }
+  }, [open, variant])
+
+  // The slot is a non-modal region (not a MUI Modal), so it doesn't get
+  // Escape-to-dismiss for free. Listen at the document level while open so
+  // keyboard users can close the panel with Escape, matching the dialog
+  // dismissal convention (WCAG 2.1.2). The overlay "drawer" variant is a MUI
+  // Modal and handles Escape itself.
+  useEffect(() => {
+    if (!open || variant !== "slot") {
+      return
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose?.()
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [open, variant, onClose])
 
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
@@ -349,7 +381,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       <Header>
         <Title>
           <RiMegaphoneLine aria-hidden />
-          <Heading id={headingId}>
+          <Heading id={headingId} ref={headingRef} tabIndex={-1}>
             {subtitle ? (
               <>
                 {title} about <BlockName>{subtitle}</BlockName>
@@ -453,7 +485,12 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       return null
     }
     return (
-      <Container className={className} data-smoot-version={VERSION}>
+      <Container
+        className={className}
+        data-smoot-version={VERSION}
+        role="region"
+        aria-labelledby={headingId}
+      >
         {content}
       </Container>
     )

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -285,9 +285,8 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
   const [rateLimited, setRateLimited] = useState(false)
-  // Bumped whenever a reaction is committed (activated by pointer or
-  // Enter/Space) so an effect can move focus into the comment field that
-  // appears. Arrow-key roving doesn't bump it, so it doesn't move focus.
+  // Monotonic counter bumped by commitReaction; the effect below keys on it (not
+  // on sentiment) so re-committing the same reaction still refocuses the comment.
   const [commitSeq, setCommitSeq] = useState(0)
 
   const active =
@@ -337,11 +336,9 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [open, variant, onClose])
 
-  // After a reaction is committed (not while arrow-roving), move focus into the
-  // freshly revealed comment field so screen-reader users are taken to it;
-  // selecting a reaction otherwise gives no cue that a text field appeared.
-  // Keyed on commitSeq so re-activating the same reaction refocuses too; the
-  // > 0 guard keeps an initial defaultSentiment mount from stealing focus.
+  // Move focus into the freshly revealed comment field so screen-reader users
+  // are taken to it (selecting a reaction otherwise gives no cue a text field
+  // appeared). The > 0 guard skips the initial defaultSentiment mount.
   useEffect(() => {
     if (commitSeq > 0) {
       commentRef.current?.focus()

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -345,14 +345,19 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     }
   }, [commitSeq])
 
+  // Selection follows focus: focusing a reaction — whether the Tab order lands
+  // on it, arrow roving moves onto it, or a pointer presses it — selects it and
+  // reveals its comment prompt. This keeps every reaction consistent, so the
+  // first radio the Tab order lands on previews its field the same way the
+  // others do. It only roves selection; it never moves focus itself.
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
     setStatus("idle")
   }
 
   // Pointer/Enter/Space activation commits the choice and (via the effect above)
-  // moves focus into the comment field. Arrow keys call selectReaction directly,
-  // so they only rove selection within the group and leave focus on the radios.
+  // moves focus into the comment field. Focus alone (Tab or arrow roving) only
+  // previews via selectReaction and leaves focus on the radios.
   const commitReaction = (key: Sentiment) => {
     selectReaction(key)
     setCommitSeq((seq) => seq + 1)
@@ -408,6 +413,36 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
         (error as { status?: number })?.status === RATE_LIMIT_STATUS,
       )
       setStatus("error")
+    }
+  }
+
+  // Keep keyboard focus inside the open slot: Tab past the last control wraps to
+  // the first, Shift+Tab past the first wraps to the last. The slot is a
+  // non-modal region, so without this the tab order spills into unrelated page
+  // chrome (e.g. the site footer) instead of staying with the feedback task.
+  const handleContainerKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (event.key !== "Tab") {
+      return
+    }
+    const tabbable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        "a[href], button, input, textarea, select, [tabindex]",
+      ),
+    ).filter((el) => el.tabIndex >= 0 && !(el as HTMLButtonElement).disabled)
+    if (tabbable.length === 0) {
+      return
+    }
+    const first = tabbable[0]
+    const last = tabbable[tabbable.length - 1]
+    const activeEl = document.activeElement
+    if (event.shiftKey && activeEl === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && activeEl === last) {
+      event.preventDefault()
+      first.focus()
     }
   }
 
@@ -471,6 +506,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                     selected={selected}
                     colorKey={reaction.colorKey}
                     tintAlpha={reaction.tintAlpha}
+                    onFocus={() => selectReaction(reaction.key)}
                     onClick={() => commitReaction(reaction.key)}
                     onKeyDown={(event) => handleReactionKeyDown(event, index)}
                   >
@@ -526,11 +562,15 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       return null
     }
     return (
+      // Focus-containment guard only (keeps Tab within the open drawer); the
+      // region itself isn't an interactive control.
+      // eslint-disable-next-line styled-components-a11y/no-noninteractive-element-interactions
       <Container
         className={className}
         data-smoot-version={VERSION}
         role="region"
         aria-labelledby={headingId}
+        onKeyDown={handleContainerKeyDown}
       >
         {content}
       </Container>

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -143,9 +143,14 @@ const Heading = styled.h1(({ theme }) => ({
   margin: 0,
   color: theme.custom.colors.darkGray2,
   overflowWrap: "anywhere",
-  // The heading is focused programmatically on open (never via Tab), so the
-  // keyboard focus ring meant for tab navigation would be visual noise here.
-  "&:focus": { outline: "none" },
+  // Ring for keyboard opens only (data-focus-ring); a mouse open focuses the
+  // heading silently. Not :focus-visible — focus is programmatic across the
+  // iframe boundary, so the opener signals modality instead. (WCAG 2.4.7)
+  "&[data-focus-ring]:focus": {
+    outline: `2px solid ${theme.custom.colors.darkGray2}`,
+    outlineOffset: "2px",
+    borderRadius: "2px",
+  },
 }))
 
 const BlockName = styled.span(({ theme }) => ({
@@ -247,6 +252,8 @@ type FeedbackDrawerProps = {
    */
   variant?: "drawer" | "slot"
   open?: boolean
+  /** Keyboard-initiated open: the slot shows a focus ring on the heading. */
+  openedViaKeyboard?: boolean
   onClose?: () => void
   onSubmit?: (data: FeedbackData) => Promise<void> | void
   /** Drawer heading. */
@@ -260,6 +267,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   className,
   variant = "drawer",
   open,
+  openedViaKeyboard,
   onClose,
   onSubmit,
   title = "Share your feedback",
@@ -381,7 +389,12 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
       <Header>
         <Title>
           <RiMegaphoneLine aria-hidden />
-          <Heading id={headingId} ref={headingRef} tabIndex={-1}>
+          <Heading
+            id={headingId}
+            ref={headingRef}
+            tabIndex={-1}
+            data-focus-ring={openedViaKeyboard ? "" : undefined}
+          >
             {subtitle ? (
               <>
                 {title} about <BlockName>{subtitle}</BlockName>

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -204,6 +204,22 @@ describe("FeedbackDrawerManager", () => {
     iframe.remove()
   })
 
+  test("calls onClose when the drawer closes so the host can hide the slot", async () => {
+    const onClose = jest.fn()
+    render(
+      <FeedbackDrawerManager
+        messageOrigin={ORIGIN}
+        variant="slot"
+        onClose={onClose}
+      />,
+      { wrapper: ThemeProvider },
+    )
+    openMessage()
+    screen.getByText("How was this content?")
+    await user.click(screen.getByRole("button", { name: "Close" }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   test("primes the CSRF cookie when missing, then POSTs with the token", async () => {
     const PRIME_URL = "http://localhost:4567/users/me"
     const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -61,6 +61,37 @@ describe("FeedbackDrawerManager", () => {
     expect(screen.queryByText("How was this content?")).toBeNull()
   })
 
+  test("passes a keyboard-open through to the drawer's focus-ring marker", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ORIGIN,
+          data: {
+            type: "ol-feedback::drawer-open",
+            payload: PAYLOAD,
+            viaKeyboard: true,
+          },
+        }),
+      )
+    })
+    expect(screen.getByRole("heading", { level: 1 })).toHaveAttribute(
+      "data-focus-ring",
+    )
+  })
+
+  test("omits the focus-ring marker for a mouse open (no keyboard flag)", () => {
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    openMessage()
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveAttribute(
+      "data-focus-ring",
+    )
+  })
+
   test("opens the drawer and POSTs the mapped body on submit", async () => {
     const fetchMock = jest
       .spyOn(global, "fetch")

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.test.tsx
@@ -139,6 +139,40 @@ describe("FeedbackDrawerManager", () => {
     screen.getByTestId("feedback-drawer-manager-waiting")
   })
 
+  test("posts a drawer-closed message back to the opener when closed", async () => {
+    // The megaphone trigger lives in a cross-origin LMS iframe, so the manager
+    // (running in the MFE parent) can't focus it directly. On close it must
+    // signal the opener window (event.source) so the trigger can refocus itself.
+    const iframe = document.createElement("iframe")
+    document.body.appendChild(iframe)
+    const opener = iframe.contentWindow as Window
+    const postSpy = jest
+      .spyOn(opener, "postMessage")
+      .mockImplementation(() => {})
+
+    render(<FeedbackDrawerManager messageOrigin={ORIGIN} variant="slot" />, {
+      wrapper: ThemeProvider,
+    })
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ORIGIN,
+          source: opener,
+          data: { type: "ol-feedback::drawer-open", payload: PAYLOAD },
+        }),
+      )
+    })
+    screen.getByText("How was this content?")
+
+    await user.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(postSpy).toHaveBeenCalledWith(
+      { type: "ol-feedback::drawer-closed" },
+      ORIGIN,
+    )
+    iframe.remove()
+  })
+
   test("primes the CSRF cookie when missing, then POSTs with the token", async () => {
     const PRIME_URL = "http://localhost:4567/users/me"
     const fetchMock = jest.spyOn(global, "fetch").mockImplementation((url) => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -35,6 +35,9 @@ type FeedbackDrawerManagerProps = {
 
 const OPEN_MESSAGE = "ol-feedback::drawer-open"
 const CLOSE_MESSAGE = "ol-feedback::drawer-close"
+// Sent back to the opener when the drawer closes so the (cross-origin) trigger
+// can return keyboard focus to its megaphone button.
+const CLOSED_MESSAGE = "ol-feedback::drawer-closed"
 
 const FeedbackDrawerManager = ({
   messageOrigin,
@@ -52,6 +55,10 @@ const FeedbackDrawerManager = ({
   // Tracks the pending open-animation frame so a close can cancel it, otherwise
   // a close arriving before the frame fires would be overridden by setOpen(true).
   const openRafRef = useRef<number | null>(null)
+  // The window that requested the open (the LMS iframe hosting the megaphone).
+  // Captured so we can tell it to refocus its trigger on close; that button is
+  // cross-origin, so the MFE parent can't focus it directly.
+  const openerRef = useRef<Window | null>(null)
 
   const cancelPendingOpen = useCallback(() => {
     if (openRafRef.current !== null) {
@@ -67,7 +74,9 @@ const FeedbackDrawerManager = ({
       setPayload(null)
     }
     setOpen(false)
-  }, [variant, cancelPendingOpen])
+    // Return keyboard focus to the megaphone trigger in the opener iframe.
+    openerRef.current?.postMessage({ type: CLOSED_MESSAGE }, messageOrigin)
+  }, [variant, cancelPendingOpen, messageOrigin])
 
   useEffect(() => {
     const cb = (event: MessageEvent) => {
@@ -78,6 +87,7 @@ const FeedbackDrawerManager = ({
         | { type?: string; payload?: FeedbackPayload }
         | undefined
       if (data?.type === OPEN_MESSAGE) {
+        openerRef.current = event.source as Window | null
         setPayload(data.payload || {})
         setOpenSeq((seq) => seq + 1)
         if (variant === "slot") {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -14,6 +14,8 @@ type FeedbackPayload = {
 type FeedbackOpenMessage = {
   type: "ol-feedback::drawer-open"
   payload: FeedbackPayload
+  /** True when the opener's trigger was activated by keyboard (click detail 0). */
+  viaKeyboard?: boolean
 }
 
 type FeedbackEnrichment = {
@@ -50,6 +52,9 @@ const FeedbackDrawerManager = ({
 }: FeedbackDrawerManagerProps) => {
   const [payload, setPayload] = useState<FeedbackPayload | null>(null)
   const [open, setOpen] = useState(false)
+  // Keyboard-initiated open (opener sends detail === 0) → drawer rings the
+  // heading; a mouse open focuses it silently.
+  const [openedViaKeyboard, setOpenedViaKeyboard] = useState(false)
   // Bumped on every open so each open remounts FeedbackDrawer (resets state).
   const [openSeq, setOpenSeq] = useState(0)
   // Tracks the pending open-animation frame so a close can cancel it, otherwise
@@ -84,10 +89,11 @@ const FeedbackDrawerManager = ({
         return
       }
       const data = event.data as
-        | { type?: string; payload?: FeedbackPayload }
+        | { type?: string; payload?: FeedbackPayload; viaKeyboard?: boolean }
         | undefined
       if (data?.type === OPEN_MESSAGE) {
         openerRef.current = event.source as Window | null
+        setOpenedViaKeyboard(!!data.viaKeyboard)
         setPayload(data.payload || {})
         setOpenSeq((seq) => seq + 1)
         if (variant === "slot") {
@@ -177,6 +183,7 @@ const FeedbackDrawerManager = ({
       key={openSeq}
       variant={variant}
       open={open}
+      openedViaKeyboard={openedViaKeyboard}
       subtitle={payload.blockDisplayName}
       onClose={handleClose}
       onSubmit={handleSubmit}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -33,6 +33,9 @@ type FeedbackDrawerManagerProps = {
   csrfPrimeUrl?: string
   variant?: "drawer" | "slot"
   getEnrichment?: () => FeedbackEnrichment
+  /** Notifies the host (e.g. the MFE sidebar coordinator) that the drawer
+   * closed, so it can hide the surrounding slot/column now that it's empty. */
+  onClose?: () => void
 }
 
 const OPEN_MESSAGE = "ol-feedback::drawer-open"
@@ -49,6 +52,7 @@ const FeedbackDrawerManager = ({
   csrfPrimeUrl,
   variant = "drawer",
   getEnrichment,
+  onClose,
 }: FeedbackDrawerManagerProps) => {
   const [payload, setPayload] = useState<FeedbackPayload | null>(null)
   const [open, setOpen] = useState(false)
@@ -81,7 +85,9 @@ const FeedbackDrawerManager = ({
     setOpen(false)
     // Return keyboard focus to the megaphone trigger in the opener iframe.
     openerRef.current?.postMessage({ type: CLOSED_MESSAGE }, messageOrigin)
-  }, [variant, cancelPendingOpen, messageOrigin])
+    // Let the host (MFE coordinator) hide the slot/column now that it's empty.
+    onClose?.()
+  }, [variant, cancelPendingOpen, messageOrigin, onClose])
 
   useEffect(() => {
     const cb = (event: MessageEvent) => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawerManager.tsx
@@ -64,9 +64,8 @@ const FeedbackDrawerManager = ({
   // Tracks the pending open-animation frame so a close can cancel it, otherwise
   // a close arriving before the frame fires would be overridden by setOpen(true).
   const openRafRef = useRef<number | null>(null)
-  // The window that requested the open (the LMS iframe hosting the megaphone).
-  // Captured so we can tell it to refocus its trigger on close; that button is
-  // cross-origin, so the MFE parent can't focus it directly.
+  // The opener window (LMS iframe with the megaphone), captured to postMessage
+  // it to refocus its trigger on close — cross-origin, so we can't focus it.
   const openerRef = useRef<Window | null>(null)
 
   const cancelPendingOpen = useCallback(() => {


### PR DESCRIPTION
### What are the relevant tickets?

- Fixes [mitodl/hq#12876](https://github.com/mitodl/hq/issues/12876) — Feedback Button (on RC): focus does not move to the dialog
- Also fixes [mitodl/hq#12892](https://github.com/mitodl/hq/issues/12892) — "Share your feedback" dialog: screen reader issues (reaction-group labelling + focus into the comment on select; originally PR #251, now combined here)
- Feature umbrella: mitodl/hq#11629

### Description (What does it do?)

The inline (`slot`) feedback drawer — the variant deployed on RC — had no focus management, so opening it left keyboard and screen-reader users stranded on the underlying course page (WCAG 2.4.3 Focus Order, 2.4.7 Focus Visible). This adds focus management to the `slot` variant: keyboard and SR users are taken into the panel on open and returned to the courseware 📣 megaphone on close. Non-modal by design — the courseware behind the panel stays interactive.

On close the manager also calls a host-facing `onClose` callback so the MFE coordinator can collapse the (now empty) sidebar column, in addition to posting `ol-feedback::drawer-closed` down to the LMS iframe for focus return.

It also fixes the reaction group's screen-reader semantics (originally PR #251): the three-reaction group is now named by its on-screen question ("How was this content?") instead of a mismatched `aria-label`, and committing a reaction (pointer, Enter, or Space) moves focus into the freshly revealed comment box — while arrow keys only rove selection within the group (focus stays on the radios) so options can be compared (WCAG 1.3.1, 2.4.3, 4.1.2).

### Screenshots (if appropriate):

N/A — keyboard/focus behavior. See **How can this be tested?**

### How can this be tested?

**Automated:** `nvm use 24 && yarn test src/bundles/FeedbackDrawer` — 31 pass. Covers **#12876** (focus-on-open, labelled region, Escape-to-close, `drawer-closed` post-back, `onClose` host-notify, keyboard-vs-mouse focus ring) **and #12892** (reaction group named by its visible question — no stray "rate" wording; focus moves into the comment box on click and on keyboard activation; arrow keys rove selection without stealing focus from the radios). The focus ring is CSS, so it's verified manually below, not in jsdom.

**Manual** — to exercise the full megaphone → drawer → focus-return loop locally:

1. **Set up a Tutor instance** locally and **mount `frontend-app-learning`** (run its dev server).
2. **Enable the trigger:** install the companion `ol_openedx_feedback` plugin ([open-edx-plugins#853](https://github.com/mitodl/open-edx-plugins/pull/853)) in the LMS and turn on the `ol_openedx_feedback.feedback_enabled` CourseWaffleFlag (globally or per course).
3. **Wire the feedback drawer** into the Learning MFE's right-sidebar slot (see the lehrer companion, [lehrer#83](https://github.com/mitodl/lehrer/pull/83)) — `SidebarAIDrawerCoordinator` mounts it inline. In `.env.development` set `DEPLOYMENT_NAME='mitxonline'` and `ENABLE_AI_DRAWER_SLOT='true'` (feedback shares AskTIM's sidebar mount).
4. **Build this branch and copy the bundle into the MFE** (paths assume the two repos are siblings):
   ```bash
   cd smoot-design && nvm use 24 && yarn install && yarn build:bundles:feedback \
     && mkdir -p ../frontend-app-learning/public/static/smoot-design \
     && cp dist/bundles/feedbackDrawerManager.* ../frontend-app-learning/public/static/smoot-design/
   ```
   The MFE loads it from `/static/smoot-design/feedbackDrawerManager.es.js` (override with `FEEDBACK_DRAWER_BUNDLE_PATH`).
5. **Open a courseware unit as a signed-in learner**, then keyboard-only:
   1. **Focus-in** — Tab to the 📣 (or click), press Enter → the drawer opens in the sidebar and focus lands inside it (heading), with a visible ring. One more Tab → a reaction/Close, not the page. ← core [#12876](https://github.com/mitodl/hq/issues/12876) fix
   2. **Escape** — press Escape → the drawer closes.
   3. **Focus-return** — after Escape or Close, focus jumps back to the 📣 (focus ring; Enter reopens). ← cross-iframe half
   4. **Mouse open** — click the 📣 with the mouse → the drawer opens and focus lands on the heading **without** a ring (ring is keyboard-only).
   5. **Reaction → comment focus** — with the drawer open, activate a reaction (👍 / 👎 / 💡) by click, Enter, **or** Space → focus jumps into the comment textarea so you can type right away. ← [#12892](https://github.com/mitodl/hq/issues/12892)
   6. **Arrow roving** — focus a reaction and press ← / → → the selection (and its prompt) moves across the three reactions, but focus stays **on the radios**, not the comment box, so you can compare options; only click / Enter / Space commits and moves focus into the comment. ← [#12892](https://github.com/mitodl/hq/issues/12892)
6. **Screen reader** — VoiceOver is built into Mac (⌘F5 to toggle on). Redo the steps and listen:

| Step | What to listen for |
| --- | --- |
| Open (Enter on 📣) | As focus lands, VoiceOver speaks the panel — its region + heading title (e.g. "Share your feedback…, heading level 1"). Failure mode: **silence**. |
| Into the reactions | VoiceOver names the group with the on-screen question — "How was this content?, radio group" — **not** a mismatched "rate" label. ← [#12892](https://github.com/mitodl/hq/issues/12892) |
| Arrow across reactions | Each reads as a radio — e.g. "Liked it, radio button, 1 of 3". Focus stays in the group. |
| Activate a reaction (Enter / Space / click) | Focus moves to the comment box — VoiceOver announces the textarea and its prompt (e.g. "What did you like?, edit text"). ← [#12892](https://github.com/mitodl/hq/issues/12892) |
| Escape / Close | As focus returns, VoiceOver announces the 📣 megaphone by name — not silence, not "body". |

Drawer-only (no harness): the Storybook `smoot-design/Feedback/FeedbackDrawer` → **Slot (keyboard open — focus ring)** story shows the drawer + ring in isolation.

### Additional Context

- Courseware-trigger companion (sends the keyboard/mouse `viaKeyboard` flag; refocuses the megaphone on `ol-feedback::drawer-closed`): https://github.com/mitodl/open-edx-plugins/pull/853
- Learning-MFE companion (consumes the new `onClose` to collapse the empty sidebar column): https://github.com/mitodl/lehrer/pull/161
- Not live until the smoot bundle is version-bumped + published and lehrer bumps `@mitodl/smoot-design`.
