### PR TITLE
fix(feedback): label reaction group and focus comment on select

### DIFF
--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.test.tsx
@@ -24,12 +24,38 @@ describe("FeedbackDrawer", () => {
     screen.getByRole("radio", { name: "Suggestion" })
   })
 
+  test("names the reaction group with the visible question, not a mismatched label", () => {
+    renderDrawer()
+    // The group's accessible name is the on-screen "How was this content?"
+    // heading, so it matches what sighted users see (no stray "rate" wording).
+    screen.getByRole("radiogroup", { name: "How was this content?" })
+    expect(screen.queryByRole("radiogroup", { name: /rate/i })).toBeNull()
+  })
+
   test("selecting a reaction reveals its prompt, a comment box, and Submit", async () => {
     renderDrawer()
     await user.click(screen.getByRole("radio", { name: "Liked it" }))
     screen.getByText("What did you like?")
     screen.getByRole("textbox", { name: "What did you like?" })
     screen.getByRole("button", { name: "Submit" })
+  })
+
+  test("moves focus into the comment field when a reaction is clicked", async () => {
+    renderDrawer()
+    await user.click(screen.getByRole("radio", { name: "Not working" }))
+    expect(
+      screen.getByRole("textbox", { name: "What's not working?" }),
+    ).toHaveFocus()
+  })
+
+  test("moves focus into the comment field when a reaction is activated by keyboard", async () => {
+    renderDrawer()
+    const liked = screen.getByRole("radio", { name: "Liked it" })
+    liked.focus()
+    await user.keyboard("{Enter}")
+    expect(
+      screen.getByRole("textbox", { name: "What did you like?" }),
+    ).toHaveFocus()
   })
 
   test("submitting calls onSubmit and shows the success state", async () => {
@@ -88,6 +114,19 @@ describe("FeedbackDrawer", () => {
     const suggestion = screen.getByRole("radio", { name: "Suggestion" })
     expect(suggestion).toHaveAttribute("aria-checked", "true")
     expect(suggestion).toHaveFocus()
+  })
+
+  test("arrow-key selection stays on the radios and doesn't jump to the comment box", async () => {
+    renderDrawer()
+    const [first] = screen.getAllByRole("radio")
+    first.focus()
+    await user.keyboard("{ArrowRight}")
+    // Arrowing reveals the comment field but keeps focus on the group so the
+    // user can keep comparing options; only an explicit activation moves focus.
+    expect(screen.getByRole("radio", { name: "Not working" })).toHaveFocus()
+    expect(
+      screen.getByRole("textbox", { name: "What's not working?" }),
+    ).not.toHaveFocus()
   })
 
   test("renders the subtitle (content title) under the heading", () => {

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -269,13 +269,19 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
   const [rateLimited, setRateLimited] = useState(false)
+  // Bumped whenever a reaction is committed (activated by pointer or
+  // Enter/Space) so an effect can move focus into the comment field that
+  // appears. Arrow-key roving doesn't bump it, so it doesn't move focus.
+  const [commitSeq, setCommitSeq] = useState(0)
 
   const active =
     REACTIONS.find((reaction) => reaction.key === sentiment) ?? null
 
   const reactionRefs = useRef<(HTMLButtonElement | null)[]>([])
   const successRef = useRef<HTMLDivElement | null>(null)
+  const commentRef = useRef<HTMLTextAreaElement | null>(null)
   const headingId = useId()
+  const questionId = useId()
 
   // Move focus to the success message so screen-reader users are told the
   // submission succeeded (role="status" alone isn't reliably announced when the
@@ -286,9 +292,28 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     }
   }, [status])
 
+  // After a reaction is committed (not while arrow-roving), move focus into the
+  // freshly revealed comment field so screen-reader users are taken to it;
+  // selecting a reaction otherwise gives no cue that a text field appeared.
+  // Keyed on commitSeq so re-activating the same reaction refocuses too; the
+  // > 0 guard keeps an initial defaultSentiment mount from stealing focus.
+  useEffect(() => {
+    if (commitSeq > 0) {
+      commentRef.current?.focus()
+    }
+  }, [commitSeq])
+
   const selectReaction = (key: Sentiment) => {
     setSentiment(key)
     setStatus("idle")
+  }
+
+  // Pointer/Enter/Space activation commits the choice and (via the effect above)
+  // moves focus into the comment field. Arrow keys call selectReaction directly,
+  // so they only rove selection within the group and leave focus on the radios.
+  const commitReaction = (key: Sentiment) => {
+    selectReaction(key)
+    setCommitSeq((seq) => seq + 1)
   }
 
   const focusableIndex = sentiment
@@ -378,9 +403,9 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
           </Success>
         ) : (
           <>
-            <Question>How was this content?</Question>
+            <Question id={questionId}>How was this content?</Question>
 
-            <Reactions role="radiogroup" aria-label="How would you rate this?">
+            <Reactions role="radiogroup" aria-labelledby={questionId}>
               {REACTIONS.map((reaction, index) => {
                 const selected = reaction.key === sentiment
                 const Icon = selected ? reaction.FillIcon : reaction.LineIcon
@@ -399,7 +424,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                     selected={selected}
                     colorKey={reaction.colorKey}
                     tintAlpha={reaction.tintAlpha}
-                    onClick={() => selectReaction(reaction.key)}
+                    onClick={() => commitReaction(reaction.key)}
                     onKeyDown={(event) => handleReactionKeyDown(event, index)}
                   >
                     <Icon />
@@ -415,6 +440,7 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
                   multiline
                   minRows={3}
                   fullWidth
+                  inputRef={commentRef}
                   value={comment}
                   inputProps={{ maxLength: 1000, "aria-label": active.prompt }}
                   onChange={(event) => setComment(event.target.value)}

--- a/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
+++ b/src/bundles/FeedbackDrawer/FeedbackDrawer.tsx
@@ -269,9 +269,8 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
   const [comment, setComment] = useState("")
   const [status, setStatus] = useState<SubmitStatus>("idle")
   const [rateLimited, setRateLimited] = useState(false)
-  // Bumped whenever a reaction is committed (activated by pointer or
-  // Enter/Space) so an effect can move focus into the comment field that
-  // appears. Arrow-key roving doesn't bump it, so it doesn't move focus.
+  // Monotonic counter bumped by commitReaction; the effect below keys on it (not
+  // on sentiment) so re-committing the same reaction still refocuses the comment.
   const [commitSeq, setCommitSeq] = useState(0)
 
   const active =
@@ -292,11 +291,9 @@ const FeedbackDrawer: FC<FeedbackDrawerProps> = ({
     }
   }, [status])
 
-  // After a reaction is committed (not while arrow-roving), move focus into the
-  // freshly revealed comment field so screen-reader users are taken to it;
-  // selecting a reaction otherwise gives no cue that a text field appeared.
-  // Keyed on commitSeq so re-activating the same reaction refocuses too; the
-  // > 0 guard keeps an initial defaultSentiment mount from stealing focus.
+  // Move focus into the freshly revealed comment field so screen-reader users
+  // are taken to it (selecting a reaction otherwise gives no cue a text field
+  // appeared). The > 0 guard skips the initial defaultSentiment mount.
   useEffect(() => {
     if (commitSeq > 0) {
       commentRef.current?.focus()


### PR DESCRIPTION
### What are the relevant tickets?

- Fixes [mitodl/hq#12892](https://github.com/mitodl/hq/issues/12892) — "Share your feedback" dialog: screen-reader issues (NVDA)
- Feature umbrella: mitodl/hq#11629

### Description (What does it do?)

Addresses both of the ticket's recommendations for the per-block feedback drawer, reported against NVDA:

1. **Match the group's name to its visible heading.** The reaction group was labelled `aria-label="How would you rate this?"`, but the heading on screen reads "How was this content?" — so NVDA announced a name that wasn't on screen (and "rate" wrongly implied a 1–5 scale). It's now labelled by that heading via `aria-labelledby`, so the spoken name and the visible name match.
2. **Signal that the comment box appeared.** Choosing a reaction reveals a comment field, but a screen-reader user got no cue it was there. Activating a reaction — click, Enter, or Space — now moves focus into that comment field, so the user is taken straight to it. Arrow keys still only rove the highlighted choice within the group (leaving focus on the reactions), so the options stay browsable.

### Screenshots (if appropriate):

N/A — screen-reader / focus behaviour. See **How can this be tested?**

### How can this be tested?

**Automated:** `nvm use 24 && yarn test src/bundles/FeedbackDrawer`

New cases cover: the group's accessible name equals the visible heading; activating a reaction by **click** and by **keyboard** moves focus into the comment field; arrow-key roving does **not** move focus to the comment.

**Manual (screen reader):** the issue was reported on NVDA (Windows); VoiceOver on Mac (⌘F5) works for a quick check too.

1. Start Storybook: `nvm use 24 && yarn install && yarn start` → open **smoot-design → Feedback → FeedbackDrawer → Slot (inline)**. (Or use the RC course page linked in the ticket.)
2. Turn the screen reader on, Tab into the reaction group, and check each step:

| Do this | Expected announcement / behaviour |
| --- | --- |
| Move into the reaction group | The group is announced as **"How was this content?"** — the same text as the visible heading (was "How would you rate this?"). |
| Activate a reaction with Enter, Space, or a click | Focus jumps into the comment text box and the screen reader announces it, so you know a field appeared. |
| Arrow ← / → across the reactions | The highlighted choice moves between "Liked it / Not working / Suggestion" and focus stays on the reactions — it does **not** jump to the comment box. |

### Additional Context

The ticket lists exactly two recommendations and each maps to one change above — nothing else is needed for #12892. Focus management for the same drawer (moving focus in on open / back to the megaphone on close, WCAG 2.4.3) is handled separately in #250.